### PR TITLE
Feature/qap 429 sonarcloud scalable process to s

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Mobtest validations
       run: |
-        mobtest --sonar_issues_path ./mobtest-issues.json .
+        mobtest --sonar_issues_path ./generic-reports/mobtest-issues.json .
 
     - name: Raise version and validate Ros repository
       run: mobros raise --workspace="$(pwd)" 
@@ -128,7 +128,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.externalIssuesReportPaths=./mobtest-issues.json
+          -Dsonar.externalIssuesReportPaths=./generic-reports/*
 
     - name: Link to SonarQube Dashboard
       shell: bash

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Mobtest validations
       run: |
-        mkdir ./generic-reports
+        mkdir -p ./generic-reports
         mobtest --sonar_issues_path ./generic-reports/mobtest-issues.json .
 
     - name: Raise version and validate Ros repository
@@ -118,6 +118,9 @@ jobs:
       id: test
       shell: bash
       run: |
+        # guarantee folder is created
+        mkdir -p ./generic-reports
+
         # get all files in ./generic-reports
         generic_reports=$(find ./generic-reports -maxdepth 1 -type f)
         # join with ,

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -100,6 +100,7 @@ jobs:
 
     - name: Mobtest validations
       run: |
+        mkdir ./generic-reports
         mobtest --sonar_issues_path ./generic-reports/mobtest-issues.json .
 
     - name: Raise version and validate Ros repository

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -117,10 +117,13 @@ jobs:
     - name: Collect generic reports
       shell: bash
       run: |
-        generic_reports=$(ls ./generic-reports)
-        generic_reports=$(echo "$generic_reports" | sed "s/^/.\/generic\//g")
+        # get all files in ./generic-reports
+        generic_reports=$(find ./generic-reports -maxdepth 1 -type f)
+        # join with ,
         generic_reports=$(echo "${generic_reports[@]}" | tr '\n' ',')
+        # remove last ','
         generic_reports=${generic_reports::-1}
+
         echo "Generic reports: ${generic_reports}"
         echo ::set-output name=generic_paths::${generic_reports}
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -115,7 +115,7 @@ jobs:
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
     - name: Collect generic reports
-      id: vars
+      id: test
       shell: bash
       run: |
         # get all files in ./generic-reports
@@ -126,7 +126,7 @@ jobs:
         generic_reports=${generic_reports::-1}
 
         echo "Generic reports: ${generic_reports}"
-        echo ::set-output name=generic_paths::${generic_reports}
+        echo ::set-output name=generic_reports::${generic_reports}
 
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v1.0.0
@@ -143,7 +143,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.externalIssuesReportPaths=${{ steps.vars.outputs.generic_paths }}
+          -Dsonar.externalIssuesReportPaths=${{ steps.test.outputs.generic_reports }}
 
     - name: Link to SonarQube Dashboard
       shell: bash

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -115,6 +115,7 @@ jobs:
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
     - name: Collect generic reports
+      id: vars
       shell: bash
       run: |
         # get all files in ./generic-reports

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -114,6 +114,16 @@ jobs:
         export MOVAI_OUTPUT_DIR="$(pwd)/artifacts"
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
+    - name: Collect generic reports
+      shell: bash
+      run: |
+        generic_reports=$(ls ./generic-reports)
+        generic_reports=$(echo "$generic_reports" | sed "s/^/.\/generic\//g")
+        generic_reports=$(echo "${generic_reports[@]}" | tr '\n' ',')
+        generic_reports=${generic_reports::-1}
+        echo "Generic reports: ${generic_reports}"
+        echo ::set-output name=generic_paths::${generic_reports}
+
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v1.0.0
       env:
@@ -129,7 +139,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.externalIssuesReportPaths=./generic-reports/*
+          -Dsonar.externalIssuesReportPaths=${{ steps.vars.outputs.generic_paths }}
 
     - name: Link to SonarQube Dashboard
       shell: bash


### PR DESCRIPTION
:warning: Should be merged only after merging #18 and solving the conflicts!

First steps to generalize SonarQube/Cloud usage.
Current plan is to get all workflows (npm, ROS, python, ...) writing reports to the same folders and then have a generic Sonar workflow collecting reports from those generic folders.