### PR TITLE
QAP-425 python formatting and linting

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: 'false'
+      run_black:
+        required: false
+        type: string
+        default: 'false'
+        description: When 'true' black is run stopping the pipeline if any files are not properly formatted
 
     secrets:
       auto_commit_user:
@@ -64,11 +69,15 @@ jobs:
       if: steps.check_files.outputs.files_exists == 'true'
       uses: pre-commit/action@v3.0.0
 
+    - name: Run Black
+      if: ${{ inputs.run_black == 'true' }}
+      run: |
+        python3 -m black --line-length 100 --diff --check .
+
     - name: Python Linter
       if: ${{ inputs.skip_linting == 'true' }}
       run: |
         python3 -m pylint *
-        python3 -m black .
         python3 -m flake8
 
     - name: SonarCloud Scan

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -63,16 +63,6 @@ jobs:
     - name: install build-requirements
       run: python3 -m pip install -r build-requirements.txt
 
-    - name: Check if pre-commit config exists
-      id: check_files
-      uses: andstor/file-existence-action@v1
-      with:
-        files: ".pre-commit-config.yaml"
-
-    - name: Run pre-commit
-      if: steps.check_files.outputs.files_exists == 'true'
-      uses: pre-commit/action@v3.0.0
-
     - name: Run Black
       if: ${{ inputs.run_black == 'true' }}
       run: |
@@ -314,7 +304,7 @@ jobs:
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
     - name: Fetch artifact from github release
-      run: | 
+      run: |
         git config --global --add safe.directory $(pwd)
         mkdir dist
         cd dist
@@ -328,7 +318,7 @@ jobs:
       with:
         name: packages
         path: dist/*
-        
+
     - name: Publish package to ${{ matrix.publish_repo }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -250,7 +250,7 @@ jobs:
         password: ${{ secrets.nexus_publisher_password }}
         repository_url: https://artifacts.cloud.mov.ai/repository/pypi-experimental/
 
-    - name: Publish package to TestPyPI Testing
+    - name: Publish package to TestPyPI Integration
       if: ${{ inputs.deploy == 'true' }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -74,11 +74,12 @@ jobs:
       run: |
         python3 -m black --line-length 100 --diff --check .
 
-    - name: Python Linter
-      if: ${{ inputs.skip_linting == 'true' }}
+    - name: Python Linters
       run: |
-        python3 -m pylint *
-        python3 -m flake8
+        python3 -m flake8 --isolated \
+          --exclude .git,__pycache__,dist,venv,.tox \
+          --output-file flake8-report.txt
+        python3 -m pylint --max-complexity 10 --output pylint-report.txt *
 
     - name: SonarCloud Scan
       if: ${{ !github.event.repository.private }}

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -79,6 +79,7 @@ jobs:
           .
 
     - name: Python Linters
+      # run linters isolated so no issues are masked from SonarCloud
       run: |
         python3 -m flake8 \
           --isolated \
@@ -87,7 +88,12 @@ jobs:
           --max-line-length 100 \
           --exit-zero \
           --output-file flake8-report.txt
+
+        # pylint seems to not have a way to ignore configuration files
+        # so we need to provide it a dummy one
+        touch dummy-pylint-config
         python3 -m pylint \
+          --rcfile dummy-pylint-config \
           --ignore-patterns dist,.*\.egg-info,.git,__pycache__,.tox,venv \
           --max-line-length 100 \
           --exit-zero \

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -72,14 +72,28 @@ jobs:
     - name: Run Black
       if: ${{ inputs.run_black == 'true' }}
       run: |
-        python3 -m black --line-length 100 --diff --check .
+        python3 -m black
+          --line-length 100 \
+          --diff \
+          --check \
+          .
 
     - name: Python Linters
       run: |
-        python3 -m flake8 --isolated \
-          --exclude .git,__pycache__,dist,venv,.tox \
+        python3 -m flake8 \
+          --isolated \
+          --exclude dist,.*\.egg-info,.git,__pycache__,.tox,venv \
+          --max-complexity 10 \
+          --max-line-length 100 \
+          --exit-zero \
           --output-file flake8-report.txt
-        python3 -m pylint --max-complexity 10 --output pylint-report.txt *
+        python3 -m pylint \
+          --ignore-patterns dist,.*\.egg-info,.git,__pycache__,.tox,venv \
+          --max-line-length 100 \
+          --exit-zero \
+          --recursive y \
+          --output pylint-report.txt \
+          .
 
     - name: SonarCloud Scan
       if: ${{ !github.event.repository.private }}
@@ -97,6 +111,8 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
+          -Dsonar.python.flake8.reportPaths=flake8-report.txt
+          -Dsonar.python.pylint.reportPaths=pylint-report.txt
 
     - name: Link to SonarCloud dashboard
       if: ${{ !github.event.repository.private }}


### PR DESCRIPTION
Changes on Python workflow:
* Remove `skip_linting` parameter
* Run black under `run_black` parameter, stopping the pipeline and showing what would change
* Run flake8, not stopping the pipeline if issues are found, forward issues to SonarCloud
* Run pylint, not stopping the pipeline if issues are found, forward issues to SonarCloud

Risks:
* Removing `skip_linting` parameter is a risk, but according to a search in [Github](https://github.com/search?q=org%3AMOV-AI+skip_linting&type=code) the only repository which uses this workflow and is using the parameter is mobtest's. I'll take care of fixing it. But if we don't remove it from the parameters list, there is no risk at all. Let me know if I should remove it