### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    - id: check-json                # checks if json files are valid
+    - id: check-added-large-files   # checks if large files were added
+    - id: check-merge-conflict      # checks if all merge conflicts were resolved
+    - id: check-yaml                # checks if yaml files are valid
+    - id: end-of-file-fixer         # fixes missing line ending in end of file
+    - id: mixed-line-ending         # fixes line files line ending
+      args: [--fix=lf]
+    - id: trailing-whitespace       # removes trailing whitespaces from text files
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.18.3
+    hooks:
+      - id: check-github-workflows


### PR DESCRIPTION
Hi,
I've been using pre-commit locally when committing here for some time, this PR adds the pre-commit config.
One of the tools configured is a validator of the github workflows schema.
It works but its output is not so clear, in this example I replaced `env:` with `envv:`. It detected the error, but the output is not clear:
```
$ pre-commit run -a                                                                                                                   check json...........................................(no files to check)Skipped                                                                                                                                    check for added large files..............................................Passed                                                                                                                                    check for merge conflicts................................................Passed                                                                                                                                    fix end of files.........................................................Passed                                                                                                                                    mixed line ending........................................................Passed                                                                                                                                    trim trailing whitespace.................................................Passed                                                                                                                                    Validate GitHub Workflows................................................Failed                                                                                                                                    - hook id: check-github-workflows                                                                                                                                                                                  - exit code: 1                                                                                           
                                                    
ok -- validation done                               
Schema validation errors were encountered.                                                               
  .github/workflows/py-workflow.yml::$.jobs.Build: {'if': "${{ inputs.release == 'false' }}",
...
ITHUB_TOKEN': '${{ secrets.gh_token }}'}}]} is not valid under any of the given schemas
  Underlying errors caused this.
  Best Match:
    $.jobs.Build: 'uses' is a required property
ok -- validation done
```

If it happens that you commit workflows that do not respect the schema, this might help.