### PR TITLE
By default stop on mobtest error

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -10,7 +10,7 @@ on:
           type: string
         continue_on_mobtest_error:
           required: false
-          type: string
+          type: boolean
           default: false
 
     secrets:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -8,10 +8,10 @@ on:
         ros_distro:
           required: true
           type: string
-        stop_on_mobtest_error:
+        continue_on_mobtest_error:
           required: false
           type: string
-          default: true
+          default: false
 
     secrets:
       auto_commit_user:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -8,6 +8,10 @@ on:
         ros_distro:
           required: true
           type: string
+        stop_on_mobtest_error:
+          required: false
+          type: string
+          default: true
 
     secrets:
       auto_commit_user:
@@ -60,7 +64,7 @@ jobs:
             apt install -y yamllint
             yamllint product-manifest.yaml
 
-    - name: Install CI Scripts 
+    - name: Install CI Scripts
       shell: bash
       run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
@@ -121,8 +125,8 @@ jobs:
 
     - name: Agent info
       run: curl ipinfo.io/ip
-    
-    - name: Install CI Scripts 
+
+    - name: Install CI Scripts
       shell: bash
       run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
@@ -140,7 +144,7 @@ jobs:
             export PATH="$HOME/.local/bin:$PATH"
             cat product-manifest.yaml
             integration-pipeline generate_meta_artifacts --update_simulator --override_spawner ${{ inputs.product_name }} --manifest_platform_base_key "product-dependencies"
-    
+
     - name: Stash manifest
       uses: actions/upload-artifact@v2
       with:
@@ -153,21 +157,21 @@ jobs:
             wget https://github.com/hadolint/hadolint/releases/download/v2.9.3/hadolint-Linux-x86_64
             chmod +x hadolint-Linux-x86_64
             ./hadolint-Linux-x86_64 docker/${{ matrix.distro }}/Dockerfile -t error
-    
+
     - name: Login to Private Registry
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.registry_user }}
         password: ${{ secrets.registry_password }}
-        registry: ${{ env.REGISTRY }} 
+        registry: ${{ env.REGISTRY }}
 
     - name: Prepare docker build variables
       id: pre_build
       run: |
-            echo ::set-output name=base_name::$(cat ci_artifacts/spawner_base_name_${{ matrix.distro }}.ci)  
+            echo ::set-output name=base_name::$(cat ci_artifacts/spawner_base_name_${{ matrix.distro }}.ci)
             echo ::set-output name=base_version::$(cat ci_artifacts/spawner_base_version_${{ matrix.distro }}.ci)
-            echo ::set-output name=raised_version::$(cat product.version) 
-            
+            echo ::set-output name=raised_version::$(cat product.version)
+
 
     - name: Build with args and push:${{ inputs.deploy }}
       uses: docker/build-push-action@v3
@@ -180,10 +184,10 @@ jobs:
         pull: true
         build-args: |
           DOCKER_REGISTRY=${{ env.REGISTRY }}
-          BASE_IMAGE=${{ steps.pre_build.outputs.base_name }} 
-          TAG=${{ steps.pre_build.outputs.base_version }} 
+          BASE_IMAGE=${{ steps.pre_build.outputs.base_name }}
+          TAG=${{ steps.pre_build.outputs.base_version }}
           CI_SCRIPT_VERSION=${{ env.CI_INTEGRATION_SCRIPTS_VERSION }}
-  
+
     - name: Installation
       shell: bash
       run: |
@@ -206,6 +210,7 @@ jobs:
             rm movai_service_version
 
     - name: Run mobtest
+      continue-on-error: ${{ stop_on_mobtest_error }}
       shell: bash
       run: |
             container_id=$(docker ps --format '{{.Names}}' --filter "name=^spawner-.*")
@@ -213,7 +218,7 @@ jobs:
               set -e
               export PATH="$HOME/.local/bin:$PATH"
               python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple mobtest==${{ env.MOBTEST_VERSION }} --ignore-installed
-              mobtest proj /opt/ros/${{ matrix.distro }}/share/ || true
+              mobtest proj /opt/ros/${{ matrix.distro }}/share/
               '
     - name: Collect Installed components
       shell: bash
@@ -232,7 +237,7 @@ jobs:
               CONFIG_FILE_NAME=${{ inputs.product_name }}-${{ matrix.distro }}.json
 
               echo "$REGISTRY/qa/${{ inputs.product_name }}-${{ matrix.distro }}:$(cat product.version)">artifacts/product-${{ matrix.distro }}.image.artifact
-  
+
     - name: Push image
       uses: docker/build-push-action@v3
       with:
@@ -244,8 +249,8 @@ jobs:
         pull: true
         build-args: |
           DOCKER_REGISTRY=${{ env.REGISTRY }}
-          BASE_IMAGE=${{ steps.pre_build.outputs.base_name }} 
-          TAG=${{ steps.pre_build.outputs.base_version }} 
+          BASE_IMAGE=${{ steps.pre_build.outputs.base_name }}
+          TAG=${{ steps.pre_build.outputs.base_version }}
           CI_SCRIPT_VERSION=${{ env.CI_INTEGRATION_SCRIPTS_VERSION }}
 
     - name: Stash deploy_artifacts_noetic
@@ -259,7 +264,7 @@ jobs:
       run: |
         docker system prune -f
         docker image prune --all -f
-  
+
   Build-Simulator:
     needs: [Validate-boostrap-configs]
     runs-on: integration-pipeline
@@ -271,7 +276,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install CI Scripts 
+    - name: Install CI Scripts
       shell: bash
       run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
@@ -315,13 +320,13 @@ jobs:
       with:
         username: ${{ secrets.registry_user }}
         password: ${{ secrets.registry_password }}
-        registry: ${{ env.REGISTRY }} 
+        registry: ${{ env.REGISTRY }}
 
     - name: Prepare docker build variables
       if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
       id: pre_build
       run: |
-            echo ::set-output name=image_name::$(cat simulator_artifacts/simulator_name.ci)  
+            echo ::set-output name=image_name::$(cat simulator_artifacts/simulator_name.ci)
             echo ::set-output name=base_name::$(cat simulator_artifacts/simulator_base.ci)
 
     - name: Build with args and push:${{ inputs.deploy }}
@@ -407,7 +412,7 @@ jobs:
         name: deploy_simulator_artifacts
         path: .
 
-    - name: Install CI Scripts 
+    - name: Install CI Scripts
       shell: bash
       run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
@@ -454,8 +459,8 @@ jobs:
             git restore product.version
             git pull
             echo "$product_version" > product.version
-            
-            
+
+
             git add product.version
             git commit -m "Automatic Raise"
       env:
@@ -488,7 +493,7 @@ jobs:
       if: always()
       id: pre_slack
       run: |
-            MESSAGE=":white_check_mark: CI: ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/}), build: $(cat product.version) is stable :sunny: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" 
+            MESSAGE=":white_check_mark: CI: ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/}), build: $(cat product.version) is stable :sunny: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             MESSAGE_ERR=":x: CI: ${GITHUB_REPOSITORY}, (${GITHUB_REF#refs/heads/}), build: $(cat product.version) is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             echo ::set-output name=msg::$MESSAGE
             echo ::set-output name=msg_error::$MESSAGE_ERR


### PR DESCRIPTION
By default mobtest errors should break the pipeline.
For 2.2.3 will be disabled (since the issues were not yet fixed) in the following PRs:
* https://github.com/MOV-AI/project-tugbot/pull/148