### PR TITLE
change to ui_framework execution params

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -194,7 +194,6 @@ jobs:
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.target_dir --output_file /tmp/target_dir.txt
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.version --output_file /tmp/version.txt
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.name --output_file /tmp/repo_name.txt
-          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.jira_report --output_file /tmp/jira_report.txt
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.test_set --output_file /tmp/test_set.txt
 
           tests_dir=$(cat /tmp/target_dir.txt)
@@ -377,7 +376,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
           pytest -s \
-            --cucumberjson="results/reports/result.json" \
             --hub_url http://172.22.0.105:4444 \
             --browser_name chrome \
             --browser_version 91.0 \
@@ -385,7 +383,7 @@ jobs:
             --username ${{ steps.install.outputs.movai_user }} \
             --password ${{ steps.install.outputs.movai_pwd }} \
             --tb=short \
-            --jira_report ${{ steps.ui_tests_setup.outputs.report_jira }}
+            --jira_report
           deactivate
           rm -R venv
 


### PR DESCRIPTION
with version 2.3.0-4 of the UI Framework, --jira_report is now a flag, no longer a parameter that requires value based on a (pre)defined variable in the pipeline. Removing references to that variable. Also, removing --cucumberjson, since it is now being invoked in pytest.ini.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
