### PR TITLE
Specify Python version on sonar execution

### DIFF
--- a/.github/workflows/multi-py-deb-workflow.yml
+++ b/.github/workflows/multi-py-deb-workflow.yml
@@ -482,6 +482,7 @@ jobs:
             -Dsonar.scm.provider=git
             -Dsonar.qualitygate.wait=true
             -Dsonar.qualitygate.timeout=300
+            -Dsonar.python.version=3
             -Dsonar.python.flake8.reportPaths=flake8-report.txt
             -Dsonar.python.pylint.reportPaths=pylint-report.txt
             -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/py-deb-workflow.yml
+++ b/.github/workflows/py-deb-workflow.yml
@@ -136,6 +136,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
+          -Dsonar.python.version=3
           -Dsonar.python.flake8.reportPaths=flake8-report.txt
           -Dsonar.python.pylint.reportPaths=pylint-report.txt
           -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -128,6 +128,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
+          -Dsonar.python.version=3
           -Dsonar.python.flake8.reportPaths=flake8-report.txt
           -Dsonar.python.pylint.reportPaths=pylint-report.txt
           -Dsonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Tested here:
https://sonarcloud.io/summary/new_code?id=MOV-AI_metadata-static-analysis&pullRequest=102
https://github.com/MOV-AI/metadata-static-analysis/pull/102

The warning disappeared, didn't see further changes