### PR TITLE
[v2] Add ROSDEP_INSTALL_DEPENDENCY_TYPES=build env before mobros build.

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ inputs.release == 'false' }}
     runs-on: ubuntu-20.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:v1.1.5
+      image: registry.aws.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:v1.1.7
       options: --user root
       credentials:
         username: ${{secrets.registry_user}}
@@ -90,7 +90,7 @@ jobs:
         fi
 
     - name: Install Mobros
-      run: python3 -m pip install mobros==1.0.1.22 --ignore-installed
+      run: python3 -m pip install mobros==1.0.1.23 --ignore-installed
 
     - name: Setup link to Ros userspace
       run: |
@@ -101,7 +101,7 @@ jobs:
       run: mobros raise --workspace="$(pwd)"
 
     - name: Build
-      run: mobros build --mode ${{ matrix.build_mode }}
+      run: mobros build --mode ${{ matrix.build_mode }} --rosdep-install-dependency-types build
 
     - name: Pack
       run: |


### PR DESCRIPTION
- @duartecoelhomovai I thought it might not be a good idea to put this in v1 as all the current repositories might fail. V2 would be a better place as the Robotics team can adapt it into our repositories iteratively. 
- Deprecates #53 

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [ ] ~Link to relevant issues in GitHub or Jira~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
