### PR TITLE
Increased timeout of qa install test suite

### DIFF
--- a/.github/workflows/qa-install-workflow.yml
+++ b/.github/workflows/qa-install-workflow.yml
@@ -136,7 +136,7 @@ jobs:
           rm -rf ./results/*
 
       - name: Install tests suite
-        timeout-minutes: 30
+        timeout-minutes: 70
         shell: bash
         run: |
           # activate venv


### PR DESCRIPTION
timeout too short for the all suite. 4 tests might run that each one might take 15min