### PR TITLE
Fix fleet_extra_hosts values in ansible deployement

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1090,7 +1090,14 @@ jobs:
             ssh-keyscan -H $ip >> ~/.ssh/known_hosts
           done
 
-          ansible-playbook install.yml -i ../staging/hosts --key-file ~/.ssh/aws_slave.pem --extra-vars=@"$(pwd)/.."/product-manifest.yaml -e fleet_domain_dns="" -e "{\"proxycerts__remote_redis_servers_fqn\": [$(cat ../staging/manager_private_ip.txt)]}" --skip-tags "ufw,hardening"
+          ansible-playbook install.yml \
+           -i ../staging/hosts \
+           --key-file ~/.ssh/aws_slave.pem \
+           --extra-vars=@"$(pwd)/.."/product-manifest.yaml \
+           -e fleet_domain_dns="" \
+           -e "{\"proxycerts__remote_redis_servers_fqn\": [$(cat ../staging/manager_private_ip.txt)]}" \
+           -e "{\"fleet_extra_hosts\": ["172.22.0.106    registry.hel.mov.ai traefik"]}" \
+           --skip-tags "ufw,hardening"
           execution_status=$?
           deactivate
           exit $execution_status

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1096,7 +1096,7 @@ jobs:
            --extra-vars=@"$(pwd)/.."/product-manifest.yaml \
            -e fleet_domain_dns="" \
            -e "{\"proxycerts__remote_redis_servers_fqn\": [$(cat ../staging/manager_private_ip.txt)]}" \
-           -e "{\"fleet_extra_hosts\": ["172.22.0.106    registry.hel.mov.ai traefik"]}" \
+           -e '{"fleet_extra_hosts": ["172.22.0.106    registry.hel.mov.ai traefik"]}' \
            --skip-tags "ufw,hardening"
           execution_status=$?
           deactivate


### PR DESCRIPTION
- Ansible script uses an empty `fleet_extra_hosts: []` value
- Here the pipeline sets an extra hosts value for `registry.hel.mov.ai` that corresponds to the internal IP on hel cluster

---
- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
