### PR TITLE
added movai-service logs

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -743,6 +743,9 @@ jobs:
           CONTAINER_ID=$(docker ps -a --format '{{.Names}}' --filter "name=^spawner-.*")
           docker logs "${CONTAINER_ID}" &> "${CONTAINER_ID}.log"
 
+          # movai-service
+          journalctl -u movai-service --since '1hour ago' &> "movai-service.log"
+
       - name: Stash QA artifacts
         if: always()
         shell: bash
@@ -936,6 +939,9 @@ jobs:
           # spawner
           CONTAINER_ID=$(docker ps -a --format '{{.Names}}' --filter "name=^spawner-.*")
           docker logs "${CONTAINER_ID}" &> "${CONTAINER_ID}.log"
+
+          # movai-service
+          journalctl -u movai-service --since '1hour ago' &> "movai-service.log"
 
       - name: Stash QA artifacts
         if: always()

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -338,6 +338,9 @@ jobs:
           CONTAINER_ID=$(docker ps -a --format '{{.Names}}' --filter "name=^spawner-.*")
           docker logs "${CONTAINER_ID}" &> "${CONTAINER_ID}.log"
 
+          # movai-service
+          journalctl -u movai-service --no-pager --since '1hour ago' &> "movai-service.log"
+
       - name: Stash QA artifacts
         if: always()
         shell: bash

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -339,7 +339,7 @@ jobs:
           docker logs "${CONTAINER_ID}" &> "${CONTAINER_ID}.log"
 
           # movai-service
-          journalctl -u movai-service --no-pager --since '1hour ago' &> "movai-service.log"
+          journalctl -u movai-service --since '1hour ago' &> "movai-service.log"
 
       - name: Stash QA artifacts
         if: always()

--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -157,6 +157,9 @@ jobs:
           CONTAINER_ID=$(docker ps -a --format '{{.Names}}' --filter "name=^spawner-.*")
           docker logs "${CONTAINER_ID}" &> "${CONTAINER_ID}.log"
 
+          # movai-service
+          journalctl -u movai-service --since '1hour ago' &> "movai-service.log"
+
       - name: Stash QA artifacts
         if: always()
         shell: bash


### PR DESCRIPTION
context: https://movai.atlassian.net/browse/QAP-2271

**1st commit:**
Adding movai-service logs to the artifacts.

**2nd commit:**
https://www.freedesktop.org/software/systemd/man/journalctl.html --> from my understanding the pager is used by default and its handy if we want to take advantage of some of the filtering/commands/options. In this case we aren't so we could be using --no-pager or not. 

**3rd commit:**
added the movai-service logs saving to all relevant files