### PR TITLE
Add ROS pkg propagation

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: true
+      propagate_to_project:
+        required: false
+        type: boolean
+        default: false
       MOBTEST_VERSION:
         required: false
         type: string
@@ -361,6 +365,18 @@ jobs:
         prerelease: true
         generate_release_notes: true
         files: artifacts/*.deb
+
+    - name: Propagate release
+      if: ${{ inputs.propagate_to_project }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        gh workflow run "Propagate ROS repository packages to projects" \
+          --repo MOV-AI/qa-automations \
+          -f repo_name=${GITHUB_REPOSITORY#*/} \
+          -f repo_version=${{ steps.vars.outputs.ros_pkg_version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
 
   Release:
     strategy:

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -25,7 +25,7 @@ on:
         required: false
         type: boolean
         default: true
-      propagate_to_project:
+      propagate_to_projects:
         required: false
         type: boolean
         default: false
@@ -367,7 +367,7 @@ jobs:
         files: artifacts/*.deb
 
     - name: Propagate release
-      if: ${{ inputs.propagate_to_project }}
+      if: ${{ inputs.propagate_to_projects }}
       continue-on-error: true
       shell: bash
       run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -371,7 +371,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-        gh workflow run "Propagate ROS repository packages to projects" \
+        gh workflow run "Propagate ROS repository packages to projects - On Dispatch" \
           --repo MOV-AI/qa-automations \
           -f repo_name=${GITHUB_REPOSITORY#*/} \
           -f repo_version=${{ steps.vars.outputs.ros_pkg_version }}


### PR DESCRIPTION
Add `propagate_to_projects` parameter, when this parameter is set to true a [workflow](https://github.com/MOV-AI/qa-automations/blob/main/.github/workflows/PropagateRosToProjectsOnDispatch.yml) is triggered.
The workflow has the ROS repository name and built version as parameters.

The workflow performs the following actions for the repository/version provided:
* validates input data
* find ROS packages built on the repository (by checking Github release assets)
* iterates over project repositories
  * clones project
  * finds dev-x.x.x branches and iterates over them
    * checks if there is a dependency on the packages found
    * updates ROS package version and opens PR if needed

Limitations:
* the update is only performed on single ROS packages (`rosgroup` is not supported)
* the description of the automatic PR must be updated manually