### PR TITLE
DP-1073 add public containers in ghcr

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -53,6 +53,11 @@ on:
         type: string
         default: pubregistry.aws.cloud.mov.ai
         description: secondary public registry used for push
+      github_registry:
+        required: false
+        type: string
+        default: ghcr.io
+        description: github public registry used for push
       public_image:
         required: false
         type: string
@@ -85,6 +90,10 @@ on:
       pub_registry_user:
         required: false
       pub_registry_password:
+        required: false
+      github_registry_user:
+        required: false
+      github_token:
         required: false
       snyk_token:
         required: false
@@ -139,6 +148,14 @@ jobs:
           password: ${{ secrets.pub_registry_password }}
           registry: ${{ inputs.public_registry }}
 
+      - name: Login to Public Github Registry (for push permission)
+        if: ${{ inputs.public }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.github_registry_user }}
+          password: ${{ secrets.github_token }}
+          registry: ${{ inputs.github_registry }}
+
       - name: Compute docker image names
         id: get_image_names
         env:
@@ -155,12 +172,13 @@ jobs:
           # If public push is needed
           if [ "${PUBLIC_PUSH}" = "true" ]; then
             PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
-            DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP"
+            GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
+            DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP,$GITHUB_DOCKER_IMAGE_TMP"
             #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
             echo "PUB_DOCKER_IMAGE=$PUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
 
             if [ "${LATEST}" = "true" ]; then
-              DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.public_registry }}/${{ inputs.public_image }}:latest"
+              DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.public_registry }}/${{ inputs.public_image }}:latest,${{ inputs.github_registry }}/${{ inputs.public_image }}:latest"
             fi
           fi
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -19,10 +19,6 @@ on:
         type: string
         default: linux/amd64 #,linux/arm/v7
         description: list of platform to build and optionally push (comma separated)
-      github_repo:
-        required: true
-        type: string
-        description: the git repository that triggered the workflow run
       github_ref:
         required: true
         type: string
@@ -225,8 +221,8 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: |
-            org.opencontainers.image.source="https://github.com/${{ inputs.github_repo }}"
-            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ inputs.github_repo }}"
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -241,8 +237,8 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: |
-            org.opencontainers.image.source="https://github.com/${{ inputs.github_repo }}"
-            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ inputs.github_repo }}"
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -212,7 +212,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          annotations:  org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -227,7 +227,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          annotations:  org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -176,6 +176,7 @@ jobs:
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP,$GITHUB_DOCKER_IMAGE_TMP"
             #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
             echo "PUB_DOCKER_IMAGE=$PUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
+            echo "GITHUB_DOCKER_IMAGE=$GITHUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
 
             if [ "${LATEST}" = "true" ]; then
               DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.public_registry }}/${{ inputs.public_image }}:latest,${{ inputs.github_registry }}/${{ inputs.public_image }}:latest"
@@ -235,6 +236,11 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           target: ${{ inputs.target }}
           pull: true
+
+      - name: Associate Github Container Registry image with github repository
+        if: ${{ inputs.public }}
+        run: |
+          ghcr.io/cli/ghcr repo set-image --org mov-ai --container "${{ inputs.github_ref }}" "${{ inputs.public_image }}"="${{ steps.get_image_names.outputs.GITHUB_DOCKER_IMAGE }}"
 
       - name: Snyk check
         if: inputs.public && inputs.snyk_check && inputs.deploy

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -179,7 +179,6 @@ jobs:
             GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP,$GITHUB_DOCKER_IMAGE_TMP"
             #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
-            echo "PUB_DOCKER_IMAGE=$PUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
             echo "GITHUB_DOCKER_IMAGE=$GITHUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
 
             if [ "${LATEST}" = "true" ]; then
@@ -225,7 +224,9 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/${{ inputs.github_repo }}"
+          labels: |
+            org.opencontainers.image.source="https://github.com/${{ inputs.github_repo }}"
+            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -252,7 +253,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.snyk_token }}
         with:
           args: --severity-threshold=high --file=${{ inputs.docker_file }}
-          image: ${{ steps.get_image_names.outputs.PUB_DOCKER_IMAGE }}
+          image: ${{ steps.get_image_names.outputs.GITHUB_DOCKER_IMAGE }}
 
       - name: Snyk upload result to GitHub Code Scanning
         if: inputs.public && inputs.snyk_check && inputs.deploy

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -153,7 +153,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.github_registry_user }}
-          password: ${{ secrets.github_registry_password }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ inputs.github_registry }}
 
       - name: Compute docker image names
@@ -236,11 +236,6 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           target: ${{ inputs.target }}
           pull: true
-
-      - name: Associate Github Container Registry image with github repository
-        if: ${{ inputs.public }}
-        run: |
-          ghcr.io/cli/ghcr repo set-image --org mov-ai --container "${{ inputs.github_ref }}" "${{ inputs.public_image }}"="${{ steps.get_image_names.outputs.GITHUB_DOCKER_IMAGE }}"
 
       - name: Snyk check
         if: inputs.public && inputs.snyk_check && inputs.deploy

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -153,7 +153,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.github_registry_user }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.github_registry_password }}
           registry: ${{ inputs.github_registry }}
 
       - name: Compute docker image names
@@ -236,6 +236,11 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           target: ${{ inputs.target }}
           pull: true
+
+      - name: Associate Github Container Registry image with github repository
+        if: ${{ inputs.public }}
+        run: |
+          ghcr.io/cli/ghcr repo set-image --org mov-ai --container "${{ inputs.github_ref }}" "${{ inputs.public_image }}"="${{ steps.get_image_names.outputs.GITHUB_DOCKER_IMAGE }}"
 
       - name: Snyk check
         if: inputs.public && inputs.snyk_check && inputs.deploy

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -212,7 +212,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${GITHUB_REF##*/} of repo ${{ github.repository }}
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -227,7 +227,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${GITHUB_REF##*/} of repo ${{ github.repository }}
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -190,13 +190,13 @@ jobs:
       - name: Compute docker build arguments
         id: get_build_args
         run: |
-          LABEL_BUILD_ARGS_STR="--label org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
-          BUILD_ARGS_STR_LIST="${{ inputs.build_args }},$LABEL_BUILD_ARGS_STR"
-          if [ -n "$BUILD_ARGS_STR_LIST" ]; then
-            #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
-            echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT
-            echo -e "Docker build arguments:\n$BUILD_ARGS_STR_LIST"
+          BUILD_ARGS_STR_LIST="--label org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
+          if [ -n "${{ inputs.build_args }}" ]; then
+            BUILD_ARGS_STR_LIST="${{ inputs.build_args }},$BUILD_ARGS_STR_LIST"
           fi
+          #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
+          echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT
+          echo -e "Docker build arguments:\n$BUILD_ARGS_STR_LIST"
 
       - name: Download packages to include in build
         if: inputs.download_artifact
@@ -237,11 +237,6 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           target: ${{ inputs.target }}
           pull: true
-
-      - name: Associate Github Container Registry image with github repository
-        if: ${{ inputs.public }}
-        run: |
-          ghcr.io/cli/ghcr repo set-image --org mov-ai --container "${{ inputs.github_ref }}" "${{ inputs.public_image }}"="${{ steps.get_image_names.outputs.GITHUB_DOCKER_IMAGE }}"
 
       - name: Snyk check
         if: inputs.public && inputs.snyk_check && inputs.deploy

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -190,13 +190,12 @@ jobs:
       - name: Compute docker build arguments
         id: get_build_args
         run: |
-          BUILD_ARGS_STR_LIST="--label org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
-          if [ -n "${{ inputs.build_args }}" ]; then
-            BUILD_ARGS_STR_LIST="${{ inputs.build_args }},$BUILD_ARGS_STR_LIST"
+          BUILD_ARGS_STR_LIST="${{ inputs.build_args }}"
+          if [ -n "$BUILD_ARGS_STR_LIST" ]; then
+            #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
+            echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT
+            echo -e "Docker build arguments:\n$BUILD_ARGS_STR_LIST"
           fi
-          #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
-          echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT
-          echo -e "Docker build arguments:\n$BUILD_ARGS_STR_LIST"
 
       - name: Download packages to include in build
         if: inputs.download_artifact
@@ -222,6 +221,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -235,6 +235,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -212,7 +212,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${GITHUB_REF##*/} of repo ${{ github.repository }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${{ github.ref_name }} of repo ${{ github.repository }}
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -227,7 +227,7 @@ jobs:
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${GITHUB_REF##*/} of repo ${{ github.repository }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${{ github.ref_name }} of repo ${{ github.repository }}
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -93,7 +93,7 @@ on:
         required: false
       github_registry_user:
         required: false
-      github_token:
+      github_registry_password:
         required: false
       snyk_token:
         required: false
@@ -153,7 +153,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.github_registry_user }}
-          password: ${{ secrets.github_token }}
+          password: ${{ secrets.github_registry_password }}
           registry: ${{ inputs.github_registry }}
 
       - name: Compute docker image names

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -240,7 +240,9 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/${{ inputs.github_repo }}"
+          labels: |
+            org.opencontainers.image.source="https://github.com/${{ inputs.github_repo }}"
+            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -211,9 +211,8 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: |
-            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-            org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+          annotations:  org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -227,9 +226,8 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: |
-            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-            org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
+          labels: org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+          annotations:  org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -225,7 +225,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_repo }}"
+          labels: "org.opencontainers.image.source=https://github.com/${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -239,7 +239,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_repo }}"
+          labels: "org.opencontainers.image.source=https://github.com/${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -19,6 +19,10 @@ on:
         type: string
         default: linux/amd64 #,linux/arm/v7
         description: list of platform to build and optionally push (comma separated)
+      github_repo:
+        required: true
+        type: string
+        description: the git repository that triggered the workflow run
       github_ref:
         required: true
         type: string
@@ -221,7 +225,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
+          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -235,7 +239,7 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: ${{ inputs.deploy }}
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
+          labels: "org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_repo }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -1,0 +1,226 @@
+name: Build, Deploy and release Docker images
+on:
+  workflow_call:
+    inputs:
+      docker_file:
+        required: true
+        type: string
+        description: path to the Dockerfile used for build step
+      docker_image:
+        required: true
+        type: string
+        description: name of image used for build step and optional push to registries
+      build_args:
+        required: false
+        type: string
+        description: list of arguments used for build step (comma separated)
+      platforms:
+        required: false
+        type: string
+        default: linux/amd64 #,linux/arm/v7
+        description: list of platform to build and optionally push (comma separated)
+      github_ref:
+        required: true
+        type: string
+        description: the git branch or tag ref that triggered the workflow run
+      version:
+        required: false
+        type: string
+        default: local
+        description: tag of image used for build step and optional push to registries
+      deploy:
+        required: false
+        type: boolean
+        default: false
+        description: boolean to enable push
+      push_latest:
+        required: false
+        type: boolean
+        default: false
+        description: boolean to override latest tag on push
+      docker_registry:
+        required: false
+        type: string
+        default: registry.cloud.mov.ai
+        description: primary registry used for push
+      public:
+        required: false
+        type: boolean
+        default: false
+        description: boolean to enable secondary public registry push
+      public_registry:
+        required: false
+        type: string
+        default: pubregistry.aws.cloud.mov.ai
+        description: secondary public registry used for push
+      public_image:
+        required: false
+        type: string
+        description: secondary public name of image used for build step and optional push to registries
+      snyk_check:
+        required: false
+        type: boolean
+        default: false
+        description: boolean to enable snyk security analysis
+      download_artifact:
+        required: false
+        type: boolean
+        default: false
+        description: boolean to enable download of 'packages' artifacts to be included in build
+      download_artifact_path:
+        required: false
+        type: string
+        default: ./dist
+        description: path where package is downloaded
+      target:
+        required: false
+        type: string
+        default:
+        description: string of docker build target
+    secrets:
+      registry_user:
+        required: true
+      registry_password:
+        required: true
+      pub_registry_user:
+        required: false
+      pub_registry_password:
+        required: false
+      snyk_token:
+        required: false
+
+jobs:
+  build_deploy:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      packages: write  # for gcr publishing
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Hadolint ${{ inputs.docker_file }}
+        uses: hadolint/hadolint-action@v1.6.0
+        with:
+          dockerfile: ${{ inputs.docker_file }}
+          format: tty
+          failure-threshold: error # optional, default is info
+          # A space separated string of rules to ignore
+          # ignore: # optional
+          # Path to a config file
+          # config: # optional
+
+      - name: Login to Private Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.registry_user }}
+          password: ${{ secrets.registry_password }}
+          registry: ${{ inputs.docker_registry }}
+
+      - name: Login to Public Registry (for push permission)
+        if: ${{ inputs.public }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.pub_registry_user }}
+          password: ${{ secrets.pub_registry_password }}
+          registry: ${{ inputs.public_registry }}
+
+      - name: Compute docker image names
+        id: get_image_names
+        env:
+          PUBLIC_PUSH: ${{ inputs.public }}
+          LATEST: ${{ inputs.push_latest }}
+        run: |
+          PUB_DOCKER_IMAGE=""
+          DOCKER_IMAGES_TMP=${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${{ inputs.version }}
+
+          if [ "${LATEST}" = "true" ]; then
+            DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.docker_registry }}/${{ inputs.docker_image }}:latest"
+          fi
+
+          # If public push is needed
+          if [ "${PUBLIC_PUSH}" = "true" ]; then
+            PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
+            DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP"
+            #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
+            echo "PUB_DOCKER_IMAGE=$PUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
+
+            if [ "${LATEST}" = "true" ]; then
+              DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.public_registry }}/${{ inputs.public_image }}:latest"
+            fi
+          fi
+
+          #echo "::set-output name=DOCKER_IMAGES::$DOCKER_IMAGES"
+          echo "DOCKER_IMAGES=$DOCKER_IMAGES_TMP" >> $GITHUB_OUTPUT
+          echo -e "Docker images to publish:\n$DOCKER_IMAGES"
+
+      - name: Compute docker build arguments
+        id: get_build_args
+        run: |
+          BUILD_ARGS_STR_LIST="${{ inputs.build_args }}"
+          if [ -n "$BUILD_ARGS_STR_LIST" ]; then
+            #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
+            echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT
+            echo -e "Docker build arguments:\n$BUILD_ARGS_STR_LIST"
+          fi
+
+      - name: Download packages to include in build
+        if: inputs.download_artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: ${{ inputs.download_artifact_path }}
+
+      - name: Set up QEMU for multi platform
+        if: ${{ contains(inputs.platforms, 'arm') }}
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build with args and push:${{ inputs.deploy }}
+        if: ${{ steps.get_build_args.outputs.build_args_str_list != '' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          file: ${{ inputs.docker_file }}
+          push: ${{ inputs.deploy }}
+          tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          target: ${{ inputs.target }}
+          pull: true
+          build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
+
+      - name: Build and push:${{ inputs.deploy }}
+        if: ${{ steps.get_build_args.outputs.build_args_str_list == '' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          file: ${{ inputs.docker_file }}
+          push: ${{ inputs.deploy }}
+          tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          target: ${{ inputs.target }}
+          pull: true
+
+      - name: Snyk check
+        if: inputs.public && inputs.snyk_check && inputs.deploy
+        uses: snyk/actions/docker@master
+        continue-on-error: true
+        timeout-minutes: 10
+        env:
+          SNYK_TOKEN: ${{ secrets.snyk_token }}
+        with:
+          args: --severity-threshold=high --file=${{ inputs.docker_file }}
+          image: ${{ steps.get_image_names.outputs.PUB_DOCKER_IMAGE }}
+
+      - name: Snyk upload result to GitHub Code Scanning
+        if: inputs.public && inputs.snyk_check && inputs.deploy
+        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Set up QEMU for multi platform
         if: ${{ contains(inputs.platforms, 'arm') }}
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.2.0
       # https://github.com/docker/setup-buildx-action
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -19,15 +19,6 @@ on:
         type: string
         default: linux/amd64 #,linux/arm/v7
         description: list of platform to build and optionally push (comma separated)
-      github_ref:
-        required: true
-        type: string
-        description: the git branch or tag ref that triggered the workflow run
-      version:
-        required: false
-        type: string
-        default: local
-        description: tag of image used for build step and optional push to registries
       deploy:
         required: false
         type: boolean
@@ -163,7 +154,7 @@ jobs:
           LATEST: ${{ inputs.push_latest }}
         run: |
           PUB_DOCKER_IMAGE=""
-          DOCKER_IMAGES_TMP=${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${{ inputs.version }}
+          DOCKER_IMAGES_TMP=${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${GITHUB_REF##*/}
 
           if [ "${LATEST}" = "true" ]; then
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.docker_registry }}/${{ inputs.docker_image }}:latest"
@@ -171,8 +162,8 @@ jobs:
 
           # If public push is needed
           if [ "${PUBLIC_PUSH}" = "true" ]; then
-            PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
-            GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
+            PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${GITHUB_REF##*/}"
+            GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${GITHUB_REF##*/}"
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP,$GITHUB_DOCKER_IMAGE_TMP"
             #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
             echo "GITHUB_DOCKER_IMAGE=$GITHUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT
@@ -222,7 +213,7 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: |
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ github.repository }}"
+            org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
@@ -238,7 +229,7 @@ jobs:
           tags: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           labels: |
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
-            org.opencontainers.image.description="Version ${{ inputs.version }} of repo ${{ github.repository }}"
+            org.opencontainers.image.description="Version ${GITHUB_REF##*/} of repo ${{ github.repository }}"
           target: ${{ inputs.target }}
           pull: true
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -90,6 +90,17 @@ on:
         required: false
 
 jobs:
+
+  RefreshSource:
+    if: ${{ inputs.deploy == 'false' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.auto_commit_pwd }}'
+          MERGE_MSG: "Branch was auto-updated."
+
   build_deploy:
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -190,7 +190,8 @@ jobs:
       - name: Compute docker build arguments
         id: get_build_args
         run: |
-          BUILD_ARGS_STR_LIST="${{ inputs.build_args }}"
+          LABEL_BUILD_ARGS_STR="--label org.opencontainers.image.source=https://github.com/mov-ai/${{ inputs.github_ref }}"
+          BUILD_ARGS_STR_LIST="${{ inputs.build_args }},$LABEL_BUILD_ARGS_STR"
           if [ -n "$BUILD_ARGS_STR_LIST" ]; then
             #echo "::set-output name=build_args_str_list::$BUILD_ARGS_STR_LIST"
             echo "build_args_str_list=$BUILD_ARGS_STR_LIST" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -56,7 +56,7 @@ on:
       github_registry:
         required: false
         type: string
-        default: ghcr.io
+        default: ghcr.io/mov-ai
         description: github public registry used for push
       public_image:
         required: false


### PR DESCRIPTION
Changes in docker-workflow.yml to automatically save generated images to Github Container Registry. In order to test the implemented changes, the repository https://github.com/MOV-AI/containers-mariana-test was created. By running the workflow, docker images were generated under the name ce/mariana-hello-world and saved in:
- the nexus public repository (https://artifacts.aws.cloud.mov.ai/#browse/browse:public:v2%2Fce%2Fmariana-hello-world)
- the github container registry (https://github.com/MOV-AI/containers-mariana-test/pkgs/container/ce%2Fmariana-hello-world) 

The successful run of the changed workflow is here: https://github.com/MOV-AI/containers-mariana-test/actions/runs/5655869348

The latest version is v1.7, which already contains a description.

If the pull request is accepted, the created images as well as the test repository should be deleted and the following changes should be applied to all containers repositories:
- change branch of .github to which docker-cli.yml points from v1 to v2
- add to docker-cli pipeline:
    - secrets github_registry_user and github_registry_password
- remove from docker-cli pipeline:
    - inputs github_ref and version 
   

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
