### PR TITLE
Bugfix/DP-1239 wrong version on container images

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -201,9 +201,9 @@ jobs:
 
           IFS=', ' read -r -a platforms_array <<< "${{ inputs.platforms }}"
           if [ ${#platforms_array[@]} -gt 1 ]; then
-            OUTPUTS_ARGS_STR_LIST="type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${{ github.ref_name }} of repo ${{ github.repository }}"
+            OUTPUTS_ARGS_STR_LIST="type=image,name=target,annotation-index.org.opencontainers.image.description=Version ${{ inputs.version }} of repo ${{ github.repository }}"
           else
-            LABEL_DESCRIPTION="org.opencontainers.image.description=Version ${{ github.ref_name }} of repo ${{ github.repository }}"
+            LABEL_DESCRIPTION="org.opencontainers.image.description=Version ${{ inputs.version }} of repo ${{ github.repository }}"
           fi
 
           echo "label_description=$LABEL_DESCRIPTION" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -19,6 +19,11 @@ on:
         type: string
         default: linux/amd64 #,linux/arm/v7
         description: list of platform to build and optionally push (comma separated)
+      version:
+        required: false
+        type: string
+        default: local
+        description: tag of image used for build step and optional push to registries
       deploy:
         required: false
         type: boolean
@@ -154,7 +159,7 @@ jobs:
           LATEST: ${{ inputs.push_latest }}
         run: |
           PUB_DOCKER_IMAGE=""
-          DOCKER_IMAGES_TMP=${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${GITHUB_REF##*/}
+          DOCKER_IMAGES_TMP=${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${{ inputs.version }}
 
           if [ "${LATEST}" = "true" ]; then
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,${{ inputs.docker_registry }}/${{ inputs.docker_image }}:latest"
@@ -162,8 +167,8 @@ jobs:
 
           # If public push is needed
           if [ "${PUBLIC_PUSH}" = "true" ]; then
-            PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${GITHUB_REF##*/}"
-            GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${GITHUB_REF##*/}"
+            PUB_DOCKER_IMAGE_TMP="${{ inputs.public_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
+            GITHUB_DOCKER_IMAGE_TMP="${{ inputs.github_registry }}/${{ inputs.public_image }}:${{ inputs.version }}"
             DOCKER_IMAGES_TMP="$DOCKER_IMAGES_TMP,$PUB_DOCKER_IMAGE_TMP,$GITHUB_DOCKER_IMAGE_TMP"
             #echo "::set-output name=PUB_DOCKER_IMAGE::$PUB_DOCKER_IMAGE"
             echo "GITHUB_DOCKER_IMAGE=$GITHUB_DOCKER_IMAGE_TMP" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Changes in docker-workflow.yml to correctly tag generated docker images. In order to test the implemented changes, the repository https://github.com/MOV-AI/containers-mariana-test was created. By running the workflow, docker images were generated under the name mariana-hello-world and saved in:
- the nexus private repository under qa/mariana-hello-world and prod/mariana-hello-world
- the nexus public repository under ce/mariana-hello-world
- the github container registry under ce/mariana-hello-world

The successful runs of the changed workflow are here: 
- push to main (created qa/mariana-hello-world in private nexus): https://github.com/MOV-AI/containers-mariana-test/actions/runs/5753216948
- pull request to main: https://github.com/MOV-AI/containers-mariana-test/actions/runs/5753256526
- merge to main (created qa/mariana-hello-world in private nexus): https://github.com/MOV-AI/containers-mariana-test/actions/runs/5753302623
- release (created prod/mariana-hello-world in private nexus and ce/mariana-hello-world in public nexus and ghcr): https://github.com/MOV-AI/containers-mariana-test/actions/runs/5753426591

If the pull request is accepted, the created images as well as the test repository should be deleted and the following changes should be applied to all containers repositories:
- add to docker-cli pipeline input "version"

------------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
