### PR TITLE
Fix for DP-1326: ROS package pipelines failing on Raise App version

### DIFF
--- a/.github/workflows/cpp-workflow.yml
+++ b/.github/workflows/cpp-workflow.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -101,7 +101,6 @@ jobs:
 
         #          curl -fsSL http://packages.osrfoundation.org/gazebo.key | apt-key add - ;add-apt-repository "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main"
 
-
     - name: SonarQube Scan
       if: ${{ false }}
       uses: SonarSource/sonarqube-scan-action@v1.0.0
@@ -124,7 +123,6 @@ jobs:
       run: |
         echo "Please check report here: https://sonarqube.aws.cloud.mov.ai/dashboard?id=${{ github.event.repository.name }}"
       id: sonar_links
-
 
     - name: Build
       run: |
@@ -163,10 +161,13 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -308,7 +309,7 @@ jobs:
         commit_hash=$(git log --format="%H" -n 1)
         #echo ::set-output name=commit_id::$commit_hash
         echo "commit_id=$commit_hash" >> $GITHUB_OUTPUT
-  
+
     - name: Create Github Release
       uses: softprops/action-gh-release@v1
       with:
@@ -333,7 +334,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/create-generic-release.yml
+++ b/.github/workflows/create-generic-release.yml
@@ -14,9 +14,13 @@ jobs:
     timeout-minutes: 30
     name: "Release Script"
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
 
     - name: Find Package details
       id: vars

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Hadolint ${{ inputs.docker_file }}
         uses: hadolint/hadolint-action@v1.6.0

--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -179,12 +179,15 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
     env:
       NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -310,7 +313,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Set tag output
       id: vars

--- a/.github/workflows/helm-workflow.yml
+++ b/.github/workflows/helm-workflow.yml
@@ -55,10 +55,12 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
-
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Set eks context and get pods
         shell: bash

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -88,7 +88,7 @@ jobs:
       slack_thread_id: ${{ fromJson(steps.send-message.outputs.slack-result).response.message.ts }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Validate Manifest
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -492,7 +492,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -806,7 +806,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -1034,7 +1034,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -1292,7 +1292,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -1610,7 +1610,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         id: agent_info
@@ -1767,7 +1767,7 @@ jobs:
       - uses: rtCamp/action-cleanup@master
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         run: |
@@ -2069,7 +2069,7 @@ jobs:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Agent info
         id: agent_info
         run: |

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -48,7 +48,6 @@ on:
         required: false
         type: boolean
         default: false
-  
 
     secrets:
       auto_commit_user:
@@ -117,11 +116,11 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ inputs.is_nightly_run == false }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Nightly Checkout
         if: ${{ inputs.is_nightly_run }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           ref: ${{ inputs.nightly_run_branch }}
 
@@ -195,7 +194,7 @@ jobs:
         shell: bash
         run: |
           MESSAGE="CI: ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/}), build: $(cat product.version)(Attempt: #${{ github.run_attempt }}) is starting to be validated :construction: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          
+
           if [ "${{ inputs.is_nightly_run }}" == "true" ] ; then
             MESSAGE="NIGHTLY: ${GITHUB_REPOSITORY} ${{inputs.nightly_run_branch}}, (Attempt: #${{ github.run_attempt }}) is starting to be validated :construction: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi
@@ -230,7 +229,7 @@ jobs:
     steps:
       - uses: rtCamp/action-cleanup@master
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         run: |
@@ -290,7 +289,7 @@ jobs:
           username: ${{ secrets.registry_user }}
           password: ${{ secrets.registry_password }}
           registry: ${{ env.MID_REGISTRY }}
-  
+
       - name: Prepare docker build variables
         id: pre_build
         shell: bash
@@ -398,7 +397,7 @@ jobs:
       - uses: rtCamp/action-cleanup@master
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         run: |
@@ -665,7 +664,7 @@ jobs:
         if: ${{ inputs.with_simulation == 'true' }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         if: ${{ inputs.with_simulation == 'true' }}
 
       - name: Agent info
@@ -851,7 +850,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.Build-Simulator.outputs.skip_simulator == 'false' && inputs.with_simulation == 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         if: ${{ inputs.with_simulation == 'true' }}
@@ -1075,7 +1074,7 @@ jobs:
         if: ${{ inputs.with_simulation_tests }}
       - name: Checkout
         if: ${{ inputs.with_simulation_tests }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         run: |
@@ -1335,7 +1334,7 @@ jobs:
           ssh robot '
           set -e
 
-          export DISPLAY="$(w -oush | grep -Eo " :[0-9]+" | uniq | cut -d \  -f 2)"            
+          export DISPLAY="$(w -oush | grep -Eo " :[0-9]+" | uniq | cut -d \  -f 2)"
           echo "Display detected (dinamic) is $DISPLAY"
           export DISPLAY=":0"
           echo "Display detected is $DISPLAY"
@@ -1384,7 +1383,7 @@ jobs:
           ssh robot '
             set -e
 
-            export DISPLAY="$(w -oush | grep -Eo " :[0-9]+" | uniq | cut -d \  -f 2)"           
+            export DISPLAY="$(w -oush | grep -Eo " :[0-9]+" | uniq | cut -d \  -f 2)"
             echo "Display detected (dinamic) is $DISPLAY"
             export DISPLAY=":0"
             echo "Display detected is $DISPLAY"
@@ -1553,7 +1552,7 @@ jobs:
       - uses: rtCamp/action-cleanup@master
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Agent info
         run: |
@@ -1800,7 +1799,7 @@ jobs:
         shell: bash
         run: |
           MESSAGE=":white_check_mark: CI: ${GITHUB_REPOSITORY} (${GITHUB_REF#refs/heads/}), build: $(cat product.version) (Attempt: #${{ github.run_attempt }}) is stable :sunny: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          
+
           if [ "${{ inputs.is_nightly_run }}" == "true" ] ; then
             MESSAGE=":white_check_mark: NIGHTLY: ${GITHUB_REPOSITORY} ${{inputs.nightly_run_branch}}, (Attempt: #${{ github.run_attempt }}) is stable :sunny: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi
@@ -1838,7 +1837,7 @@ jobs:
         shell: bash
         run: |
           MESSAGE_ERR=":x: CI: ${GITHUB_REPOSITORY}, (${GITHUB_REF#refs/heads/}), build: $(cat product.version) (Attempt: #${{ github.run_attempt }}) is unstable (or canceled) :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          
+
           if [ "${{ inputs.is_nightly_run }}" == "true" ] ; then
             MESSAGE_ERR=":x: NIGHTLY: ${GITHUB_REPOSITORY} ${{inputs.nightly_run_branch}}, (Attempt: #${{ github.run_attempt }}) is unstable (or canceled) :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi

--- a/.github/workflows/integration-deploy-product.yml
+++ b/.github/workflows/integration-deploy-product.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Set tag output
       id: vars

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -125,13 +125,16 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
     env:
       NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 
     steps:
     - name: Checkout
       if: ${{ inputs.deploy == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         submodules: recursive
 
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
@@ -270,7 +270,7 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ inputs.install_test }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: recursive
 
@@ -286,6 +286,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install mobros=${{ inputs.MOBROS_VERSION }} -y
+
       - name: Install debian artifacts
         if: ${{ inputs.install_test }}
         run: |
@@ -315,10 +316,13 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         submodules: recursive
 
@@ -450,10 +454,13 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    permissions:
+      contents: write # needed for publishing to github release
+      packages: write # needed for package publishing
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         submodules: recursive
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -316,9 +316,9 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
-    permissions:
-      contents: write # needed for publishing to github release
-      packages: write # needed for package publishing
+    # permissions:
+    #   contents: write # needed for publishing to github release
+    #   packages: write # needed for package publishing
 
     steps:
     - name: Checkout
@@ -419,16 +419,18 @@ jobs:
         echo "commit_id=$commit_hash" >> $GITHUB_OUTPUT
 
     - name: Create Github Release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: "Release of ${{ steps.vars.outputs.ros_pkg_version }}"
-        body: "Please add release notes"
-        tag_name: ${{ steps.vars.outputs.ros_pkg_version }}
-        target_commitish: ${{ steps.commit.outputs.commit_id }}
-        token: ${{ secrets.gh_token }}
-        prerelease: true
-        generate_release_notes: true
-        files: artifacts/*.deb
+      shell: bash
+      run: |
+        gh release create --prerelease --generate-notes \
+        --target "${{ steps.commit.outputs.commit_id }}" \
+        --title "Release of ${{ steps.vars.outputs.ros_pkg_version }}" \
+        --notes "Please add release notes" \
+        "${{ steps.vars.outputs.ros_pkg_version }}"
+
+        # add artifacts to release
+        find artifacts/ -type f -name "*.deb" -exec gh release upload "${{ steps.vars.outputs.ros_pkg_version }}" {} \;
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
 
     - name: Propagate release
       if: ${{ inputs.propagate_to_projects }}
@@ -454,9 +456,9 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
-    permissions:
-      contents: write # needed for publishing to github release
-      packages: write # needed for package publishing
+    # permissions:
+    #   contents: write # needed for publishing to github release
+    #   packages: write # needed for package publishing
 
     steps:
     - name: Checkout


### PR DESCRIPTION
### Context

- our GitHub organization needs to be configured with a GITHUB_TOKEN with read and write permissions: see https://github.com/enterprises/movai/settings/actions
![image](https://github.com/MOV-AI/.github/assets/84147256/301747e9-2e1c-4fb7-b568-1ace1571f70b)

- our shared workflows are called with a mix of inputs : secret.gh_token, some of them use the GITHUB_TOKEN mentioned above, others use the RAISE_BOT_COMMIT_PWD secret which has write permissions

- permissions needed per shared workflow could be clearly stated but it would impose to also state them in each workflow in each active branch of each repo :unamused:

### Goals for packages generator pipelines

1. align our pipelines on permissions
2. align our pipelines on sub github actions versions
3. align our pipelines on GH release creation
4. align failures handling: Slack notifications on failure, prevent un-needed re-build on re-runs


### Modifications
Goal1:
- added permission on each job running  `softprops/action-gh-release`  (https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128)
-

Goal 2:
- freezed checkout action to latest 

Goal 3:
- modified ros-workflow to directly call gh release instead of an action (seems as straight forward)

Goal 4:
- nothing for now
