### PR TITLE
DP-1352: fix pyopenssl not updated

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -98,7 +98,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Bootstraping simulator metadata
         run: |
@@ -196,7 +199,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         shell: bash
@@ -250,7 +256,8 @@ jobs:
           rm -rf venv
           python3 -m venv venv
           . venv/bin/activate
-          python3 -m pip install --upgrade pip
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
           pip install -r requirements.txt
           deactivate
 
@@ -503,7 +510,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         shell: bash
@@ -556,7 +566,8 @@ jobs:
           rm -rf venv
           python3 -m venv venv
           . venv/bin/activate
-          python3 -m pip install --upgrade pip
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
           pip install -r requirements.txt
           deactivate
           popd
@@ -817,7 +828,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         shell: bash
@@ -864,7 +878,8 @@ jobs:
           rm -rf venv
           python3 -m venv venv
           . venv/bin/activate
-          python3 -m pip install --upgrade pip
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
           pip install -r requirements.txt
           deactivate
           popd
@@ -1046,7 +1061,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         shell: bash
@@ -1097,7 +1115,8 @@ jobs:
           rm -rf venv
           python3 -m venv venv
           . venv/bin/activate
-          python3 -m pip install --upgrade pip
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
           pip install -r requirements.txt
           deactivate
           popd
@@ -1304,7 +1323,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash robot_configs
         uses: actions/download-artifact@v3
@@ -1570,20 +1592,7 @@ jobs:
         with:
           name: fleet_qa_artifacts
           path: ${{ steps.ansible_install_setup.outputs.target_dir }}/fleet_qa_artifacts/*
-          retention-days: 10
-
-      - name: Teardown remote vms (AWS)
-        if: ${{ false }}
-        shell: bash
-        run: |
-          echo "Deleting $(cat aws_artifacts/infra_ids.txt)"
-          python3 -m pip install awscli
-          export PATH="$HOME/.local/bin:$PATH"
-          aws ec2 terminate-instances --instance-ids $(cat aws_artifacts/infra_ids.txt)
-          echo "Deleting $(cat aws_artifacts/infra_ids.txt)"
-          python3 -m pip install awscli
-          export PATH="$HOME/.local/bin:$PATH"
-          aws ec2 terminate-instances --instance-ids $(cat aws_artifacts/infra_ids.txt)
+          retention-days: 1
 
       - name: Teardown remote vms (Proxmox)
         working-directory: ${{ steps.provision_infra_setup.outputs.target_dir }}
@@ -1622,7 +1631,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash sim_configs
         uses: actions/download-artifact@v3
@@ -1832,7 +1844,8 @@ jobs:
           rm -rf venv
           python3 -m venv venv
           . venv/bin/activate
-          python3 -m pip install --upgrade pip
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade          
           pip install -r requirements.txt
           deactivate
           popd
@@ -2109,7 +2122,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: | 
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         shell: bash

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -133,7 +133,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Bootstraping simulator metadata
         run: |
@@ -239,7 +242,10 @@ jobs:
 
       - name: Install CI Scripts
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash raised_meta
         uses: actions/download-artifact@v3
@@ -677,7 +683,10 @@ jobs:
       - name: Install CI Scripts
         if: ${{ inputs.with_simulation == 'true' }}
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash sim_configs
         if: ${{ inputs.with_simulation == 'true' }}
@@ -1086,7 +1095,10 @@ jobs:
       - name: Install CI Scripts
         if: ${{ inputs.with_simulation_tests }}
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash raised_meta
         if: ${{ inputs.with_simulation_tests }}
@@ -1321,7 +1333,8 @@ jobs:
             rm -rf venv
             python3 -m venv venv
             . venv/bin/activate
-            python3 -m pip install --upgrade pip
+            python3 -m pip install pip --upgrade
+            python3 -m pip install pyopenssl --upgrade
             pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple -r requirements.txt
             deactivate
             popd
@@ -1614,7 +1627,10 @@ jobs:
       - name: Install CI Scripts
         if: ${{ inputs.is_nightly_run == false }}
         shell: bash
-        run: python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyopenssl --upgrade
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: Install Package Deployer
         if: ${{ inputs.is_nightly_run == false }}

--- a/.github/workflows/integration-deploy-product.yml
+++ b/.github/workflows/integration-deploy-product.yml
@@ -81,6 +81,8 @@ jobs:
     - name: Install package deployer
       if: ${{ inputs.deploy_pkgs == 'true' }}
       run: |
+        python3 -m pip install pip --upgrade
+        python3 -m pip install pyopenssl --upgrade
         python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple movai-package-deployer==${{ env.PACKAGE_DEPLOYER_VERSION }} --ignore-installed
 
     - name: Download staging packages


### PR DESCRIPTION
fix pyopenssl not updated

Tested OK on erroneous vm-ip-05:
1. Error on exec of python script:
```
evops@vm-ip-05:~/actions-runner/_work/ee-project-platform/ee-project-platform$ integration-pipeline fetch_by_tag --repo $provision_infra_repo_name --version $provision_infra_version --gh_api_user $GITHUB_API_USR --gh_api_pwd *** --target_dir $provision_infra_dir
Traceback (most recent call last):
  File "/home/devops/.local/bin/integration-pipeline", line 5, in <module>
    from integration_pipeline.handler import handle
  File "/home/devops/.local/lib/python3.8/site-packages/integration_pipeline/handler.py", line 11, in <module>
    from integration_pipeline.download_models.download_models_executer import (
  File "/home/devops/.local/lib/python3.8/site-packages/integration_pipeline/download_models/download_models_executer.py", line 22, in <module>
    from integration_pipeline.utils.s3_utils import download_s3_file
  File "/home/devops/.local/lib/python3.8/site-packages/integration_pipeline/utils/s3_utils.py", line 2, in <module>
    import boto3
  File "/home/devops/.local/lib/python3.8/site-packages/boto3/__init__.py", line 17, in <module>
    from boto3.session import Session
  File "/home/devops/.local/lib/python3.8/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/client.py", line 15, in <module>
    from botocore import waiter, xform_name
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/waiter.py", line 18, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/docs/service.py", line 14, in <module>
    from botocore.docs.client import (
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/docs/client.py", line 18, in <module>
    from botocore.docs.example import ResponseExampleDocumenter
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/docs/example.py", line 13, in <module>
    from botocore.docs.shape import ShapeDocumenter
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/docs/shape.py", line 19, in <module>
    from botocore.utils import is_json_value_header
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/utils.py", line 39, in <module>
    import botocore.httpsession
  File "/home/devops/.local/lib/python3.8/site-packages/botocore/httpsession.py", line 45, in <module>
    from urllib3.contrib.pyopenssl import (
  File "/home/devops/.local/lib/python3.8/site-packages/urllib3/contrib/pyopenssl.py", line 50, in <module>
    import OpenSSL.crypto
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

2. Pip status report old pyOpenSSL installed:

```
python3 -m pip freeze | grep -i ssl
pyOpenSSL==19.0.0
```
3. installation of updated pip and pyOpenSSL:

```
python3 -m pip install pip --upgrade
python3 -m pip install pyopenssl --upgrade
...
Installing collected packages: pyopenssl
Successfully installed pyopenssl-23.3.0
```
4. Successful execution:
```
devops@vm-ip-05:~/actions-runner/_work/ee-project-platform/ee-project-platform$ integration-pipeline fetch_by_tag --repo $provision_infra_repo_name --version $provision_infra_version --gh_api_user $GITHUB_API_USR --gh_api_pwd *** --target_dir $provision_infra_dir
usage: integration-pipeline [-h] [--manifest_platform_base_key MANIFEST_PLATFORM_BASE_KEY] [--repo REPO] [--version VERSION] [--gh_api_user GH_API_USER] [--gh_api_pwd GH_API_PWD] [--target_dir TARGET_DIR]
                            [--asset_name ASSET_NAME] [--override_spawner OVERRIDE_SPAWNER] [--branch BRANCH] [--product_name PRODUCT_NAME] [--update_simulator] [--file FILE] [--key KEY] [--output_file OUTPUT_FILE]
                            [--docker_registry DOCKER_REGISTRY] [--docker_staging_registry DOCKER_STAGING_REGISTRY] [--sub_manifest SUB_MANIFEST] [--dependency_name DEPENDENCY_NAME] [--auto_fetch]
                            command
integration-pipeline: error: argument --gh_api_user: expected one argument
```

