### PR TITLE
Skip API fleet tests

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1573,7 +1573,7 @@ jobs:
 
           . venv/bin/activate
 
-          echo "Skip tests since they were never planned to run it this manner"
+          echo "Skip tests since they were never planned to run in this manner"
 
           deactivate
 

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1573,11 +1573,7 @@ jobs:
 
           . venv/bin/activate
 
-          pytest src \
-            --movai-ip ${{ steps.ansible_install_platform.outputs.manager_ip }} \
-            --movai-user admin \
-            --movai-pw admin@123 \
-            -m fleet
+          echo "Skip tests since they were never planned to run it this manner"
 
           deactivate
 


### PR DESCRIPTION
API fleet tests were not implemented considering how they would be run in the workflow. In the process of the API tests refactor changes were made that make even the setup fail.

We'll disable the test call (which was not running any tests) and revisit this once we plan to create the test infrastructure needed for fleet tests.