### PR TITLE
Keep compatibility of generic release workflow

### DIFF
--- a/.github/workflows/create-generic-release.yml
+++ b/.github/workflows/create-generic-release.yml
@@ -65,4 +65,4 @@ jobs:
         product_version=${{ steps.vars-after-raise.outputs.pkg_version }}
         gh release create -p --generate-notes --notes-start-tag ${{ steps.vars.outputs.pkg_version }} --target $commit_hash -t "Release of ${{ steps.vars-after-raise.outputs.pkg_version }}" $product_version
       env:
-        GITHUB_TOKEN: ${{ secrets.gh_token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On https://github.com/MOV-AI/.github/commit/0307af417a3673ac7fc3ac343dca70e3eb083660 the compatibility was broken, fixing it by directly using the token.