### PR TITLE
Add task to retrive nb of delivered objects

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1535,13 +1535,15 @@ jobs:
             fi
 
             extra_options=""
+            save_outputs=false
             if [ "${{ inputs.duration }}" != "UNDEFINED" ] ; then
               extra_options="--duration ${{ inputs.duration }}"
             fi
             if [[ "$(echo -e "${{ steps.simulator_tests_setup.outputs.version }}\n2.0.0-24" | sort -V | head -n1)" == "2.0.0-24" ]]; then
-              echo "save_outputs=true" >> $GITHUB_OUTPUT
+              save_outputs=true
               extra_options="$extra_options --out-values test-output.json"
             fi
+            echo "save_outputs=$save_outputs" >> $GITHUB_OUTPUT
 
             pytest \
               ${{ steps.simulator_tests_setup.outputs.test_exec_dir }} \

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1160,8 +1160,7 @@ jobs:
     needs: [Compute-timeout, Build-Spawner, Build-Simulator]
     runs-on: ${{ needs.Build-Simulator.outputs.simulator_tests_agent_name }}
     timeout-minutes: ${{ fromJSON(needs.Compute-timeout.outputs.timeout) }}
-    outputs:
-      output_values: ${{ steps.output_values.outputs }}
+
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ inputs.with_simulation_tests }}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1424,7 +1424,6 @@ jobs:
 
             tests_dir=$(cat /tmp/target_dir.txt)
             tests_version=$(cat /tmp/version.txt)
-            echo "tests_version=$tests_version" >> $GITHUB_OUTPUT
             tests_repo_name=$(cat /tmp/repo_name.txt)
             test_set=$(cat /tmp/test_set.txt)
 
@@ -1539,7 +1538,7 @@ jobs:
             if [ "${{ inputs.duration }}" != "UNDEFINED" ] ; then
               extra_options="--duration ${{ inputs.duration }}"
             fi
-            if [[ "$(echo -e "${{ steps.simulator_tests_setup.outputs.tests_version }}\n2.0.0-24" | sort -V | head -n1)" == "2.0.0-24" ]]; then
+            if [[ "$(echo -e "${{ steps.simulator_tests_setup.outputs.version }}\n2.0.0-24" | sort -V | head -n1)" == "2.0.0-24" ]]; then
               echo "save_outputs=true" >> $GITHUB_OUTPUT
               extra_options="--out-values test-output.json"
             fi

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1551,12 +1551,13 @@ jobs:
             deactivate
           '
 
-      - name: Remote - Save test info
+      - name: Stash simulation test outputs 
         if: ${{ always() && inputs.with_simulation_tests }}
-        id: output_values
-        uses: zoexx/github-action-json-file-properties@release
+        uses: actions/upload-artifact@v4
         with:
-          file_path: "test-output.json"
+          name: sim-outputs
+          path: test-output.json
+          retention-days: 5
 
       - name: Remote - Save docker container logs
         if: ${{ always() &&  inputs.with_simulation_tests }}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1160,6 +1160,8 @@ jobs:
     needs: [Compute-timeout, Build-Spawner, Build-Simulator]
     runs-on: ${{ needs.Build-Simulator.outputs.simulator_tests_agent_name }}
     timeout-minutes: ${{ fromJSON(needs.Compute-timeout.outputs.timeout) }}
+    outputs:
+      nb_delivered: ${{ steps.nb_delivered.outputs.contents }}
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ inputs.with_simulation_tests }}
@@ -1547,6 +1549,13 @@ jobs:
 
             deactivate
           '
+
+      - name: Remote - Save delivery info
+        if: ${{ always() && inputs.with_simulation_tests }}
+        id: nb_delivered
+        uses: andstor/file-reader-action@v1
+        with:
+          path: "nb_delivered.log"
 
       - name: Remote - Save docker container logs
         if: ${{ always() &&  inputs.with_simulation_tests }}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1424,6 +1424,7 @@ jobs:
 
             tests_dir=$(cat /tmp/target_dir.txt)
             tests_version=$(cat /tmp/version.txt)
+            echo "tests_version=$tests_version" >> $GITHUB_OUTPUT
             tests_repo_name=$(cat /tmp/repo_name.txt)
             test_set=$(cat /tmp/test_set.txt)
 
@@ -1510,6 +1511,7 @@ jobs:
 
       - name: Remote - Simulation Tests
         if: ${{ inputs.with_simulation_tests }}
+        id: simulation_tests
         timeout-minutes: ${{ fromJSON(needs.Compute-timeout.outputs.timeout) }}
         shell: bash
         run: |
@@ -1533,9 +1535,13 @@ jobs:
               marker="nightly"
             fi
 
-            duration_option=""
+            extra_options=""
             if [ "${{ inputs.duration }}" != "UNDEFINED" ] ; then
-              duration_option="--duration ${{ inputs.duration }}"
+              extra_options="--duration ${{ inputs.duration }}"
+            fi
+            if [[ "$(echo -e "${{ steps.simulator_tests_setup.outputs.tests_version }}\n2.0.0-24" | sort -V | head -n1)" == "2.0.0-24" ]]; then
+              echo "save_outputs=true" >> $GITHUB_OUTPUT
+              extra_options="--out-values test-output.json"
             fi
 
             pytest \
@@ -1543,20 +1549,19 @@ jobs:
               -m $marker \
               --movai-user ${{ steps.install.outputs.movai_user }} \
               --movai-pw ${{ steps.install.outputs.movai_pwd }} \
-              --out-values test-output.json \
-              $duration_option
+              $extra_options
 
             deactivate
           '
 
       - name: Remote - Save simulation test outputs
-        if: ${{ always() && inputs.with_simulation_tests }}
+        if: ${{ always() && inputs.with_simulation_tests && steps.simulation_tests.outputs.save_outputs == 'true' }}
         shell: bash
         run: |
           scp -i ~/.ssh/ci_priv_key.pem -o StrictHostKeyChecking=no ${{ steps.infra_outputs.outputs.ssh_connect_string }}:${{ env.REMOTE_WORKSPACE_PATH }}/${{ steps.simulator_tests_setup.outputs.target_dir }}/test-output.json .
 
       - name: Stash simulation test outputs 
-        if: ${{ always() && inputs.with_simulation_tests }}
+        if: ${{ always() && inputs.with_simulation_tests && steps.simulation_tests.outputs.save_outputs == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: sim-outputs

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1552,7 +1552,7 @@ jobs:
           '
 
       - name: Remote - Save simulation test outputs
-        if: ${{ inputs.with_simulation_tests }}
+        if: ${{ always() && inputs.with_simulation_tests }}
         shell: bash
         run: |
           scp -i ~/.ssh/ci_priv_key.pem -o StrictHostKeyChecking=no ${{ steps.infra_outputs.outputs.ssh_connect_string }}:${{ env.REMOTE_WORKSPACE_PATH }}/${{ steps.simulator_tests_setup.outputs.target_dir }}/test-output.json .

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1161,7 +1161,7 @@ jobs:
     runs-on: ${{ needs.Build-Simulator.outputs.simulator_tests_agent_name }}
     timeout-minutes: ${{ fromJSON(needs.Compute-timeout.outputs.timeout) }}
     outputs:
-      nb_delivered: ${{ steps.nb_delivered.outputs.contents }}
+      output_values: ${{ steps.output_values.outputs }}
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ inputs.with_simulation_tests }}
@@ -1545,17 +1545,18 @@ jobs:
               -m $marker \
               --movai-user ${{ steps.install.outputs.movai_user }} \
               --movai-pw ${{ steps.install.outputs.movai_pwd }} \
+              --out-values test-output.json \
               $duration_option
 
             deactivate
           '
 
-      - name: Remote - Save delivery info
+      - name: Remote - Save test info
         if: ${{ always() && inputs.with_simulation_tests }}
-        id: nb_delivered
-        uses: andstor/file-reader-action@v1
+        id: output_values
+        uses: zoexx/github-action-json-file-properties@release
         with:
-          path: "nb_delivered.log"
+          file_path: "test-output.json"
 
       - name: Remote - Save docker container logs
         if: ${{ always() &&  inputs.with_simulation_tests }}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1160,7 +1160,6 @@ jobs:
     needs: [Compute-timeout, Build-Spawner, Build-Simulator]
     runs-on: ${{ needs.Build-Simulator.outputs.simulator_tests_agent_name }}
     timeout-minutes: ${{ fromJSON(needs.Compute-timeout.outputs.timeout) }}
-
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ inputs.with_simulation_tests }}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1540,7 +1540,7 @@ jobs:
             fi
             if [[ "$(echo -e "${{ steps.simulator_tests_setup.outputs.version }}\n2.0.0-24" | sort -V | head -n1)" == "2.0.0-24" ]]; then
               echo "save_outputs=true" >> $GITHUB_OUTPUT
-              extra_options="--out-values test-output.json"
+              extra_options="$extra_options --out-values test-output.json"
             fi
 
             pytest \

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1551,6 +1551,12 @@ jobs:
             deactivate
           '
 
+      - name: Remote - Save simulation test outputs
+        if: ${{ inputs.with_simulation_tests }}
+        shell: bash
+        run: |
+          scp -i ~/.ssh/ci_priv_key.pem -o StrictHostKeyChecking=no ${{ steps.infra_outputs.outputs.ssh_connect_string }}:${{ env.REMOTE_WORKSPACE_PATH }}/${{ steps.simulator_tests_setup.outputs.target_dir }}/test-output.json .
+
       - name: Stash simulation test outputs 
         if: ${{ always() && inputs.with_simulation_tests }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
DO NOT MERGE

- Save simulation test outputs in artifact `sim-outputs` to be extracted to influxdb cloud.

Test (cancelled on purpose, but tasks added passed): https://github.com/MOV-AI/project-movai-studio/actions/runs/8750655304/job/24023733460

---------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
