### PR TITLE
Feature/py documentation

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -20,6 +20,11 @@ on:
         type: string
         default: 'false'
         description: When 'true' black is run stopping the pipeline if any files are not properly formatted
+      publish_docs:
+        required: false
+        type: boolean
+        default: false
+        description: When true documentation is published
       prod_publish_repos:
         required: false
         type: string
@@ -230,18 +235,19 @@ jobs:
         repository_url: https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/
 
     - name: Build docs
+      if: ${{ inputs.publish_docs }}
       run: |
         VERSION=${GITHUB_REF##*/} tox -e docs
 
     - name: Checkout gh-pages
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy == 'true' && inputs.publish_docs }}
       uses: actions/checkout@v3
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Push docs
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy == 'true' && inputs.publish_docs }}
       run: |
         cd gh-pages
 

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -229,6 +229,45 @@ jobs:
         password: ${{ secrets.nexus_publisher_password }}
         repository_url: https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/
 
+    - name: Build docs
+      run: |
+        VERSION=${GITHUB_REF##*/} tox -e docs
+
+    - name: Checkout gh-pages
+      if: ${{ inputs.deploy == 'true' }}
+      uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Push docs
+      if: ${{ inputs.deploy == 'true' }}
+      run: |
+        cd gh-pages
+
+        # create .nojekyll
+        touch .nojekyll
+
+        # delete old folder if existed
+        rm -rf ${GITHUB_REF##*/}
+
+        # copy new docs and root index.html
+        cp -r ../docs/build/* .
+
+        # update versions.json
+        ls -mQd */ | sed 's/\///g' | sed 's/^/[/' | sed 's/$/]/' > versions.json
+
+        # set user
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+
+        # commit docs
+        git add .
+        git commit -am "Updating docs for commit ${GITHUB_SHA} in ${GITHUB_REF}"
+
+        # overwrite the contents of the gh-pages branch on our github.com repo
+        git push --force --set-upstream origin gh-pages
+
     - name: Publish package to TestPyPI Integration
       if: ${{ inputs.deploy == 'true' }}
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -142,8 +142,8 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.coverage.exclusions=tests/**
-          -Dsonar.cpd.exclusions=tests/**
+          -Dsonar.coverage.exclusions=tests/**,docs/**
+          -Dsonar.cpd.exclusions=tests/**,docs/**
           -Dsonar.python.version=3
           -Dsonar.python.flake8.reportPaths=flake8-report.txt
           -Dsonar.python.pylint.reportPaths=pylint-report.txt

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'false'
         description: When 'true' black is run stopping the pipeline if any files are not properly formatted
-      publish_docs:
+      with_docs:
         required: false
         type: boolean
         default: false
@@ -235,19 +235,19 @@ jobs:
         repository_url: https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/
 
     - name: Build docs
-      if: ${{ inputs.publish_docs }}
+      if: ${{ inputs.with_docs }}
       run: |
         VERSION=${GITHUB_REF##*/} tox -e docs
 
     - name: Checkout gh-pages
-      if: ${{ inputs.deploy == 'true' && inputs.publish_docs }}
+      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
       uses: actions/checkout@v3
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Push docs
-      if: ${{ inputs.deploy == 'true' && inputs.publish_docs }}
+      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
       run: |
         cd gh-pages
 


### PR DESCRIPTION
Add documentation publishing to Python workflow:
* Limitations:
  * The branch gh-pages must be created manually
* Tests:
  * Parameter not set:
    * PR: https://github.com/MOV-AI/flows-test-core/actions/runs/8743599848/job/23994509922
    * Deployment: https://github.com/MOV-AI/flows-test-core/actions/runs/8743698731/job/23994839702
  * Parameter set:
    * PR: https://github.com/MOV-AI/flows-test-core/actions/runs/8743704870
    * Deployment: https://github.com/MOV-AI/flows-test-core/actions/runs/8743880140

The sequence might not be the best, maybe put the tasks after `Create Github Release`?