### PR TITLE
avoid name clash plus ensure pipeline long run on specific commit

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -148,6 +148,8 @@ jobs:
         password: ${{secrets.registry_password}}
     outputs:
       slack_thread_id: ${{ fromJson(steps.send-message.outputs.slack-result).response.message.ts }}
+      commit_hash: ${{ steps.Checkout.outputs.commit_hash }}
+
     steps:
       - name: Checkout
         if: ${{ inputs.is_nightly_run == false }}
@@ -158,6 +160,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.nightly_run_branch }}
+
+      - name: Checkout commit hash
+        id: Checkout
+        run: |
+          git rev-parse HEAD > commit_hash
+          echo "commit_hash=$(cat commit_hash)" >> $GITHUB_OUTPUT
 
       - name: Job Summary Header
         shell: bash
@@ -283,6 +291,7 @@ jobs:
     outputs:
       raised_version: ${{ steps.pre_build.outputs.raised_version }}
       slack_thread_id: ${{ needs.Validate-boostrap-configs.outputs.slack_thread_id }}
+      commit_hash: ${{ needs.Validate-boostrap-configs.outputs.commit_hash }}
     steps:
       - uses: rtCamp/action-cleanup@master
       - name: Checkout
@@ -293,7 +302,7 @@ jobs:
         if: ${{ inputs.is_nightly_run }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_run_branch }}
+          ref: ${{ needs.Validate-boostrap-configs.outputs.commit_hash }}
 
       - name: Agent info
         run: |
@@ -470,7 +479,7 @@ jobs:
         if: ${{ inputs.is_nightly_run }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_run_branch }}
+          ref: ${{ needs.Build-Spawner.outputs.commit_hash }}
 
       - name: Agent info
         run: |
@@ -729,6 +738,7 @@ jobs:
       skip_simulator: "${{ steps.pre_simulator_build.outputs.skip_simulator_build }}"
       simulator_tests_agent_name: "${{ steps.post_simulator_build.outputs.simul_tests_infra }}"
       slack_thread_id: ${{ needs.Validate-boostrap-configs.outputs.slack_thread_id }}
+      commit_hash: ${{ needs.Build-Spawner.outputs.commit_hash }}
     steps:
       - name: Pre clean ups
         uses: rtCamp/action-cleanup@master
@@ -742,7 +752,7 @@ jobs:
         if: ${{ inputs.with_simulation == 'true' && inputs.is_nightly_run }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_run_branch }}
+          ref: ${{ needs.Build-Spawner.outputs.commit_hash }}
 
       - name: Agent info
         if: ${{ inputs.with_simulation == 'true' }}
@@ -923,6 +933,7 @@ jobs:
     outputs:
       slack_thread_id: ${{ needs.Build-Spawner.outputs.slack_thread_id }}
       skip_simulator: ${{ needs.Build-Simulator.outputs.skip_simulator }}
+
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ needs.Build-Simulator.outputs.skip_simulator == 'false' && inputs.with_simulation == 'true' }}
@@ -935,7 +946,7 @@ jobs:
         if: ${{ needs.Build-Simulator.outputs.skip_simulator == 'false' && inputs.with_simulation == 'true' && inputs.is_nightly_run }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_run_branch }}
+          ref: ${{ needs.Build-Spawner.outputs.commit_hash }}
 
       - name: Agent info
         if: ${{ inputs.with_simulation == 'true' }}
@@ -1197,7 +1208,7 @@ jobs:
         if: ${{ inputs.with_simulation_tests && inputs.is_nightly_run }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_run_branch }}
+          ref: ${{ needs.Build-Spawner.outputs.commit_hash }}
 
 
       - name: Agent info
@@ -1271,7 +1282,7 @@ jobs:
         run: |
           branch=$(echo ${GITHUB_REF#refs/heads/} | sed "s;\.;-;g" )
 
-          local_manager_prefix="ip-$branch-standalone"
+          local_manager_prefix="ip-${{ inputs.product_name }}-$branch-standalone"
 
           echo "$local_manager_prefix"
 
@@ -1282,7 +1293,7 @@ jobs:
         working-directory: ${{ steps.provision_infra_setup.outputs.target_dir }}
         shell: bash
         run: |
-          terraform init -backend-config="key=${{ inputs.cluster }}-standalone-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
+          terraform init -backend-config="key=${{ inputs.cluster }}-${{ inputs.product_name }}-standalone-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
           terraform plan
           terraform apply -auto-approve
 

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1282,18 +1282,26 @@ jobs:
         run: |
           branch=$(echo ${GITHUB_REF#refs/heads/} | sed "s;\.;-;g" )
 
-          local_manager_prefix="ip-${{ inputs.product_name }}-$branch-standalone"
+          run_type="ci"
+          if [ "${{ inputs.is_nightly_run }}" == "true" ] ; then
+            run_type="lr"
+          fi
 
+          local_manager_prefix="ip-$run_type-${{ inputs.product_name }}-$branch"
+          
+          tf_state="${{ inputs.cluster }}-sim-$local_manager_prefix"
+          echo "$tf_state"
           echo "$local_manager_prefix"
 
           echo "simul_prefix=${local_manager_prefix}" >> $GITHUB_OUTPUT
+          echo "tfstate_name=${tf_state}" >> $GITHUB_OUTPUT
 
       - name: Provision remote vms (Proxmox)
         if: ${{ inputs.with_simulation_tests }}
         working-directory: ${{ steps.provision_infra_setup.outputs.target_dir }}
         shell: bash
         run: |
-          terraform init -backend-config="key=${{ inputs.cluster }}-${{ inputs.product_name }}-standalone-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
+          terraform init -backend-config="key=${{ steps.infra_names.outputs.tfstate_name }}.tfstate"
           terraform plan
           terraform apply -auto-approve
 


### PR DESCRIPTION
- Ensure on long runs, the commit grabbed from the specified branch is propagated throughout the jobs instead of possibly them all grabbing their own.
- Add product name to the vm name and tf state. Branch + product name + run type  are unique.