### PR TITLE
Platform build - add pull_request input to run only a subset of test without publish

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -17,6 +17,10 @@ on:
       fleet_number_members:
         required: true
         type: number
+      pull_request:
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       auto_commit_user:
@@ -1196,6 +1200,7 @@ jobs:
   Fleet-Validations:
     needs: [Validate-boostrap-configs]
     runs-on: ip-hel-queuer
+    if: inputs.pull_request == false
     steps:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
@@ -1552,6 +1557,7 @@ jobs:
   Build-Simulator:
     needs: [Validate-boostrap-configs]
     runs-on: integration-pipeline
+    if: inputs.pull_request == false
     env:
       DISTRO: noetic
     outputs:
@@ -1714,6 +1720,7 @@ jobs:
   Simulator-Validations:
     needs: [Build-Simulator]
     runs-on: integration-pipeline
+    if: inputs.pull_request == false
     steps:
       - uses: rtCamp/action-cleanup@master
 
@@ -2000,6 +2007,7 @@ jobs:
   publish:
     needs: [Validations-Finish, Fleet-Validations, Simulator-Validations]
     runs-on: integration-pipeline
+    if: inputs.pull_request == false
     outputs:
       slack_thread_id: ${{ needs.Validations-Finish.outputs.slack_thread_id }}
     steps:
@@ -2193,8 +2201,6 @@ jobs:
           slack-channel: ${{ env.SLACK_CHANNEL }}
           slack-update-message-text: ${{ steps.pre_slack.outputs.msg }}
           slack-update-message-ts: ${{ needs.Validations-Finish.outputs.slack_thread_id }}
-
-
 
   Run-Status:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Goal
allow some PRs on ee-platform project to run a subset of the integration-pipeline to verify sanity of the deliveries quicker

## Context
- on deliveries of movai-service or frontend apps, QA team is often running a dedicated workflow on qa_install_tests, qa_ui_tests repositories which is triggered manually and time consuming

- conditions to activate those kind of run would be for example:

```
name: "Integration Pipeline Platform Dev 2.4.1"
on:
  push:
    branches:
      - dev-2.4.1
    paths-ignore:
      - product.version
  pull_request:
    branches:
      - dev-2.4.1
    paths-ignore:
      - product.version
concurrency: platform_dev2_4_1

jobs:
  CI:
    uses: MOV-AI/.github/.github/workflows/integration-build-platform.yml@feat/ip-pr-checks
    with:
      product_name: "ee-platform"
      ros_distro: '["noetic"]'
      fleet_ips: '["172.22.0.54/24","172.22.0.55/24","172.22.0.56/24"]'
      fleet_number_members: 2
      pull_request: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' && contains( github.event.pull_request.labels.*.name, 'pre-release') }}
    secrets:
```
