### PR TITLE
Use path to qa-automation workflow

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -431,7 +431,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-        gh workflow run "Propagate ROS repository packages to projects - On Dispatch" \
+        gh workflow run .github/workflows/PropagateRosToProjectsOnDispatch.yml \
           --repo MOV-AI/qa-automations \
           -f repo_name=${GITHUB_REPOSITORY#*/} \
           -f repo_version=${{ steps.vars.outputs.ros_pkg_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v2
+## ros-workflow.yml
+- Use path to workflow propagating ROS packages


### PR DESCRIPTION
There seems to be a difference in behavior of gh workflow run, see https://github.com/MOV-AI/movai_autonomy_pack/actions/runs/9749124622/job/26905837555#step:16:1
![image](https://github.com/MOV-AI/.github/assets/32164122/0dd44b1f-7bf8-4076-85a1-4ba66ef0ccdc)

When running locally:
```
$ gh workflow run "Propagate ROS repository packages to projects - On Dispatch" --repo MOV-AI/qa-automations -f repo_name=movai_autonomy_pack -f repo_version=2.4.3-35
could not find any workflows named Propagate ROS repository packages to projects - On Dispatch
$ gh workflow run .github/workflows/PropagateRosToProjectsOnDispatch.yml --repo MOV-AI/qa-automations -f repo_name=movai_autonomy_pack -f repo_version=2.4.3-35
✓ Created workflow_dispatch event for PropagateRosToProjectsOnDispatch.yml at main

To see runs for this workflow, try: gh run list --workflow=PropagateRosToProjectsOnDispatch.yml
```