### PR TITLE
Forward frontend apps coverage to SonarCloud

### DIFF
--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -181,6 +181,7 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
+          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
 
     - name: Link to SonarCloud dashboard
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## frontend-workflow.yml
 - Allow to specify the version of node using a .nvmrc file, specify the version of pnpm installed and enable sonarcloud
+- Forward coverage info to SonarCloud
 
 ## npm-workflow.yml
 - Allow to specify the version of node using a .nvmrc file, specify the version of pnpm installed and enable sonarcloud


### PR DESCRIPTION
- Forward coverage info to SonarCloud
  - Tested in https://github.com/MOV-AI/frontend-npm-launcher/actions/runs/10248059580/job/28348510233