### PR TITLE
FP-2915: Run lint-staged on npm-workflow

### DIFF
--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -127,11 +127,16 @@ jobs:
     - name: Run lint-staged
       if: ${{ inputs.run_lint_staged == 'true' }}
       run: |
-        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated"
+        # stash changes done by bumping version
+        git stash
+        echo ""
+
+        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
         git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
         echo ""
 
         npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
+        echo ""
 
         # explicitly check for changes and fail if there are any
         if ! git diff --quiet HEAD; then
@@ -140,6 +145,9 @@ jobs:
           git diff --name-only HEAD
           exit 1
         fi
+
+        # unstash changes done by bumping version
+        git stash apply
 
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -99,13 +99,12 @@ jobs:
       env:
         npm_token: ${{ secrets.npm_token }}
 
-    - name: Raise App version
+    - name: Global git config
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name '${{ secrets.auto_commit_user }}'
         git config --global user.email '${{ secrets.auto_commit_mail }}'
         git config --global user.password ${{ secrets.auto_commit_pwd }}
-        ${{ inputs.pm }} version prerelease --no-git-tag-version
 
     - name: Install dependencies
       run: |
@@ -117,20 +116,9 @@ jobs:
           npm ci --loglevel verbose
         fi
 
-    - name: Build
-      run: ${{ inputs.pm }} run build
-
-    - name: Check NPM log on failure
-      if: ${{ failure() }}
-      run: cat /github/home/.npm/_logs/*.log
-
     - name: Run lint-staged
       if: ${{ inputs.run_lint_staged == 'true' }}
       run: |
-        # stash changes done by bumping version
-        git stash
-        echo ""
-
         echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
         git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
         echo ""
@@ -146,8 +134,16 @@ jobs:
           exit 1
         fi
 
-        # unstash changes done by bumping version
-        git stash apply
+    - name: Raise App version
+      run: |
+        ${{ inputs.pm }} version prerelease --no-git-tag-version
+
+    - name: Build
+      run: ${{ inputs.pm }} run build
+
+    - name: Check NPM log on failure
+      if: ${{ failure() }}
+      run: cat /github/home/.npm/_logs/*.log
 
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -99,33 +99,12 @@ jobs:
       env:
         npm_token: ${{ secrets.npm_token }}
 
-    - name: Global git config
+    - name: Raise App version
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name '${{ secrets.auto_commit_user }}'
         git config --global user.email '${{ secrets.auto_commit_mail }}'
         git config --global user.password ${{ secrets.auto_commit_pwd }}
-
-    - name: Run lint-staged
-      if: ${{ inputs.run_lint_staged == 'true' }}
-      run: |
-        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
-        git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
-        echo ""
-
-        npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
-        echo ""
-
-        # explicitly check for changes and fail if there are any
-        if ! git diff --quiet HEAD; then
-          echo ""
-          echo "ERROR, the following files have changed:"
-          git diff --name-only HEAD
-          exit 1
-        fi
-
-    - name: Raise App version
-      run: |
         ${{ inputs.pm }} version prerelease --no-git-tag-version
 
     - name: Install dependencies
@@ -144,6 +123,31 @@ jobs:
     - name: Check NPM log on failure
       if: ${{ failure() }}
       run: cat /github/home/.npm/_logs/*.log
+
+    - name: Run lint-staged
+      if: ${{ inputs.run_lint_staged == 'true' }}
+      run: |
+        # stash changes done by bumping version
+        git stash
+        echo ""
+
+        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
+        git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
+        echo ""
+
+        npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
+        echo ""
+
+        # explicitly check for changes and fail if there are any
+        if ! git diff --quiet HEAD; then
+          echo ""
+          echo "ERROR, the following files have changed:"
+          git diff --name-only HEAD
+          exit 1
+        fi
+
+        # unstash changes done by bumping version
+        git stash apply
 
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: 'false'
+      run_lint_staged:
+        required: false
+        type: string
+        default: 'false'
       run_tests:
         required: false
         type: string
@@ -119,6 +123,15 @@ jobs:
     - name: Check NPM log on failure
       if: ${{ failure() }}
       run: cat /github/home/.npm/_logs/*.log
+
+    - name: Run lint-staged
+      if: ${{ inputs.run_lint_staged == 'true' }}
+      run: |
+        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated"
+        git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
+        echo ""
+
+        npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
 
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -99,12 +99,33 @@ jobs:
       env:
         npm_token: ${{ secrets.npm_token }}
 
-    - name: Raise App version
+    - name: Global git config
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name '${{ secrets.auto_commit_user }}'
         git config --global user.email '${{ secrets.auto_commit_mail }}'
         git config --global user.password ${{ secrets.auto_commit_pwd }}
+
+    - name: Run lint-staged
+      if: ${{ inputs.run_lint_staged == 'true' }}
+      run: |
+        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
+        git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
+        echo ""
+
+        npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
+        echo ""
+
+        # explicitly check for changes and fail if there are any
+        if ! git diff --quiet HEAD; then
+          echo ""
+          echo "ERROR, the following files have changed:"
+          git diff --name-only HEAD
+          exit 1
+        fi
+
+    - name: Raise App version
+      run: |
         ${{ inputs.pm }} version prerelease --no-git-tag-version
 
     - name: Install dependencies
@@ -123,31 +144,6 @@ jobs:
     - name: Check NPM log on failure
       if: ${{ failure() }}
       run: cat /github/home/.npm/_logs/*.log
-
-    - name: Run lint-staged
-      if: ${{ inputs.run_lint_staged == 'true' }}
-      run: |
-        # stash changes done by bumping version
-        git stash
-        echo ""
-
-        echo "The following files were changed from origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} and will be validated:"
-        git --no-pager diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only
-        echo ""
-
-        npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
-        echo ""
-
-        # explicitly check for changes and fail if there are any
-        if ! git diff --quiet HEAD; then
-          echo ""
-          echo "ERROR, the following files have changed:"
-          git diff --name-only HEAD
-          exit 1
-        fi
-
-        # unstash changes done by bumping version
-        git stash apply
 
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -133,6 +133,14 @@ jobs:
 
         npx lint-staged --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
 
+        # explicitly check for changes and fail if there are any
+        if ! git diff --quiet HEAD; then
+          echo ""
+          echo "ERROR, the following files have changed:"
+          git diff --name-only HEAD
+          exit 1
+        fi
+
     - name: Run tests
       if: ${{ inputs.run_tests == 'true' }}
       run: ${{ inputs.pm }} run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 ## npm-workflow.yml
 - Allow to specify the version of node using a .nvmrc file, specify the version of pnpm installed and enable sonarcloud
 - Forward coverage info to SonarCloud
+- Run lint-staged


### PR DESCRIPTION
[FP-2915](https://movai.atlassian.net/browse/FP-2915)

Run lint-staged in CI:
* Lint-staged is a tool with similar capabilities to pre-commit
* We would like to use it to run linters on commit and also on the CI


[FP-2915]: https://movai.atlassian.net/browse/FP-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ