### PR TITLE
bump image version. have fleet manager as ubuntu server

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1227,7 +1227,7 @@ jobs:
         shell: bash
         run: |
           env_configs_dir=infra_env_configs
-          env_configs_version=0.1.0-3
+          env_configs_version=0.1.0-6
           env_configs_repo_name=devops-tf-env-conf
 
           rm -rf $env_configs_dir


### PR DESCRIPTION
Current env_conf has manager using ubuntu desktop which has gh_cli installed. This bump switches hel manager to server.