### PR TITLE
Baremetal ISO workflow :  adapt for manual_request

### DIFF
--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -52,6 +52,8 @@ on:
         required: true
       nexus_publisher_password:
         required: true
+      slack_token_id:
+        required: False
 env:
   RUN_STAGING_DIR: "/home/devops/iso-ci/staging/${{ github.repository }}/${{ github.run_id}}/"
   NFS_SERVER_PATH: "/media/nas-mary/template/iso/baremetal"
@@ -258,6 +260,7 @@ jobs:
 
       - name: Slack message success
         uses: slackapi/slack-github-action@v1.25.0
+        if: ${{ inputs.slack_channel }}
         with:
           channel-id: ${{ inputs.slack_channel }}
           slack-message: ${{ steps.pre_slack.outputs.msg }}
@@ -265,7 +268,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
       - name: Slack message failure
-        if: failure()
+        if: failure() && ${{ inputs.slack_channel }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: ${{ inputs.slack_channel }}

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -56,10 +56,12 @@ env:
   RUN_STAGING_DIR: "/home/devops/iso-ci/staging/${{ github.repository }}/${{ github.run_id}}/"
   PROXMOX_NFS_SERVER_PATH: "/media/nas-mary/template/iso/baremetal"
   PROXMOX_NFS_SERVER_URL: "https://hel.mov.ai:8006/#v1:0:=storage%2Fhel%2Fnas-mary:4:5:=contentIso:::::"
+  NAS_URL: "http://10.10.1.46:8080/"
 
 jobs:
   Build:
     outputs:
+      current_version: ${{ steps.raise.outputs.current_version }}
       raised_version: ${{ steps.raise.outputs.raised_version }}
       file_name: ${{ steps.prepare_deploy.outputs.file_name }}
     runs-on: packer-runner
@@ -91,6 +93,7 @@ jobs:
           echo $RAISED_COMP_VERSION>version
           echo $RAISED_COMP_VERSION
           echo "raised_version=$RAISED_COMP_VERSION" >> $GITHUB_OUTPUT
+          echo "current_version=$COMP_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create config file
         run: |
@@ -216,7 +219,7 @@ jobs:
         run: |
           # test if inputs.manual_request is set
           if [ "${{ inputs.manual_request }}" == "true" || "${{ inputs.manual_request }}" == "True" ]; then
-            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH/${{ inputs.PRODUCT_NAME }}_${{ inputs.PRODUCT_VERSION }}_offline_install.iso
+            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH/${{ inputs.PRODUCT_NAME }}_${{ inputs.PRODUCT_VERSION }}_${{ needs.Build.outputs.current_version }}
           else
             PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH
           fi
@@ -229,7 +232,7 @@ jobs:
         run: |
           sudo mkdir -p "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
           sudo rsync --progress -z $RUN_STAGING_DIR/${{ needs.Build.outputs.file_name }} "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
-          echo "Image copied to NFS server to $PROXMOX_NFS_SERVER_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          echo "Image copied to NFS server to $NAS_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
 
       - name: Prepare slack variables
         if: always()
@@ -237,10 +240,14 @@ jobs:
         env:
           PROXMOX_NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.PROXMOX_NFS_SERVER_DEPLOY_PATH }}
         run: |
-          deploy_msg="Image copied to NFS server to $PROXMOX_NFS_SERVER_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
-          MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
-          MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
+          deploy_msg="Image copied to NFS server to $NAS_URL:\n\t with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          if [ "${{ inputs.manual_request }}" == "true" ] || [ "${{ inputs.manual_request }}" == "True" ]; then
+            MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:\n\n${deploy_msg}"
+            MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details:
+          else:
+            MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
+            MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fi
           echo "msg=${MESSAGE}" >> $GITHUB_OUTPUT
           echo "msg_error=${MESSAGE_ERR}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -136,7 +136,7 @@ jobs:
           mkdir -p offline_install_artifacts/json
           gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "$PRODUCT_JSON_NAME" -D offline_install_artifacts/json
         env:
-          PRODUCT_NAME: "project-${{ inputs.PRODUCT_NAME }}"
+          PRODUCT_NAME: "${{ inputs.PRODUCT_NAME }}"
           PRODUCT_VERSION: "${{ inputs.PRODUCT_VERSION }}"
           PRODUCT_JSON_NAME: "${{ inputs.PRODUCT_JSON_NAME }}"
           GITHUB_TOKEN: ${{ secrets.auto_commit_pwd }}

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -255,12 +255,12 @@ jobs:
         env:
           NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.NFS_SERVER_DEPLOY_PATH }}
         run: |
-          deploy_msg="Image copied to NFS server to $NAS_URL:\n\t with path $NFS_SERVER_DEPLOY_PATH"
+          deploy_msg="Image copied to NFS server to $NAS_URL with path $NFS_SERVER_DEPLOY_PATH"
           if [ "${{ inputs.manual_request }}" == "true" ] || [ "${{ inputs.manual_request }}" == "True" ]; then
-            MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:\n\n${deploy_msg}"
+            MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:. Details: ${deploy_msg}"
             MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           else
-            MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
+            MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:. Details: ${deploy_msg}"
             MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi
           echo "msg=${MESSAGE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -243,7 +243,7 @@ jobs:
           deploy_msg="Image copied to NFS server to $NAS_URL:\n\t with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
           if [ "${{ inputs.manual_request }}" == "true" ] || [ "${{ inputs.manual_request }}" == "True" ]; then
             MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:\n\n${deploy_msg}"
-            MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details:
+            MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           else:
             MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
             MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -17,6 +17,10 @@ on:
       PRODUCT_NAME:
         type: string
         required: true
+      PRODUCT_JSON_NAME:
+        type: string
+        required: false
+        default: "manager-spawner-${{ inputs.PRODUCT_NAME }}-noetic.json"
       PRODUCT_VERSION:
         type: string
         required: true
@@ -126,6 +130,16 @@ jobs:
           GITHUB_API_PWD: ${{ secrets.auto_commit_pwd }}
           PRODUCT_NAME: ${{ inputs.PRODUCT_NAME }}
           PRODUCT_VERSION: ${{ inputs.PRODUCT_VERSION }}
+
+      - name: Fetch release json configuration file
+        run: |
+          mkdir -p offline_install_artifacts/json
+          gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "$PRODUCT_JSON_NAME" -d offline_install_artifacts/json
+        env:
+          PRODUCT_NAME: "project-${{ inputs.PRODUCT_NAME }}"
+          PRODUCT_VERSION: "${{ inputs.PRODUCT_VERSION }}"
+          PRODUCT_JSON_NAME: "${{ inputs.PRODUCT_JSON_NAME }}"
+          GITHUB_TOKEN: ${{ secrets.auto_commit_pwd }}
 
       - name: Run the script
         run: |

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -33,6 +33,10 @@ on:
         required: false
         type: string
         default: "C05UYMX2U0K"
+      manual_request:
+        type: boolean
+        required: false
+        default: false
     secrets:
       auto_commit_user:
         required: true
@@ -61,6 +65,7 @@ jobs:
     runs-on: packer-runner
     steps:
       - uses: rtCamp/action-cleanup@master
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -72,7 +77,7 @@ jobs:
       - name: Lint with shellcheck
         uses: azohra/shell-linter@latest
         with:
-          path: ./*.bash
+          path: ./*.bash,./scripts/*.bash,./scripts/*.sh
 
       - name: Raise Version
         id: raise
@@ -118,7 +123,6 @@ jobs:
           PRODUCT_NAME: ${{ inputs.PRODUCT_NAME }}
           PRODUCT_VERSION: ${{ inputs.PRODUCT_VERSION }}
 
-
       - name: Run the script
         run: |
           mv offline_install_artifacts/* .
@@ -149,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Commit raise
-        if: ${{ inputs.deploy == 'true' }}
+        if: ${{ inputs.deploy == 'true' && inputs.manual_request == false }}
         run: |
           git config --global --add safe.directory $(pwd)
           git config --global user.name '${{ secrets.auto_commit_user }}'
@@ -162,11 +166,13 @@ jobs:
           git commit -m "[skip actions] Automatic Bump of image version to ${{ needs.Build.outputs.raised_version }}"
 
       - name: Prepare raise variables
+        if: ${{ inputs.deploy == 'true' && inputs.manual_request == false }}
         id: pre_raise_push
         run: |
           echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
       - name: Raise App version
+        if: ${{ inputs.deploy == 'true' && inputs.manual_request == false }}
         uses: CasperWA/push-protected@v2.14.0
         with:
           token: ${{ secrets.auto_commit_pwd }}
@@ -174,6 +180,7 @@ jobs:
           unprotect_reviews: true
 
       - name: Commit info
+        if: ${{ inputs.deploy == 'true' && inputs.manual_request == false }}
         id: commit
         shell: bash
         run: |
@@ -181,6 +188,7 @@ jobs:
           echo "commit_id=$commit_hash" >> $GITHUB_OUTPUT
 
       - name: Create Github Release
+        if: ${{ inputs.deploy == 'true' && inputs.manual_request == false }}
         uses: softprops/action-gh-release@v1
         with:
           name: "Release of ${{ needs.Build.outputs.raised_version }}"
@@ -203,22 +211,44 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy images to NFS server
+      - name: Compute NFS folder name
+        id: compute_nfs_folder
         run: |
-          sudo mkdir -p $PROXMOX_NFS_SERVER_PATH/
+          # test if inputs.manual_request is set
+          if [ "${{ inputs.manual_request }}" == "true" || "${{ inputs.manual_request }}" == "True" ]; then
+            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH/${{ inputs.PRODUCT_NAME }}_${{ inputs.PRODUCT_VERSION }}_offline_install.iso
+          else
+            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH
+          fi
+          echo "PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_DEPLOY_PATH" >> $GITHUB_OUTPUT
 
-          sudo rsync --progress -z $RUN_STAGING_DIR/${{ needs.Build.outputs.file_name }} $PROXMOX_NFS_SERVER_PATH/
-          echo "Image copied to NFS server to $PROXMOX_NFS_SERVER_URL"
+
+      - name: Deploy images to NFS server
+        env:
+          PROXMOX_NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.PROXMOX_NFS_SERVER_DEPLOY_PATH }}
+        run: |
+          sudo mkdir -p "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          sudo rsync --progress -z $RUN_STAGING_DIR/${{ needs.Build.outputs.file_name }} "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          echo "Image copied to NFS server to $PROXMOX_NFS_SERVER_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
 
       - name: Prepare slack variables
         if: always()
         id: pre_slack
+        env:
+          PROXMOX_NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.PROXMOX_NFS_SERVER_DEPLOY_PATH }}
         run: |
-          MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:"
+          deploy_msg="Image copied to NFS server to $PROXMOX_NFS_SERVER_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
           MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           echo "msg=${MESSAGE}" >> $GITHUB_OUTPUT
           echo "msg_error=${MESSAGE_ERR}" >> $GITHUB_OUTPUT
+
+      - name: Write summary message in Github Actions
+        if: always()
+        run: |
+          summary_message="${{ steps.pre_slack.outputs.msg }}"
+          echo -e "${summary_message}" >> $GITHUB_STEP_SUMMARY
 
       # - name: Slack message success
       #   uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -54,9 +54,8 @@ on:
         required: true
 env:
   RUN_STAGING_DIR: "/home/devops/iso-ci/staging/${{ github.repository }}/${{ github.run_id}}/"
-  PROXMOX_NFS_SERVER_PATH: "/media/nas-mary/template/iso/baremetal"
-  PROXMOX_NFS_SERVER_URL: "https://hel.mov.ai:8006/#v1:0:=storage%2Fhel%2Fnas-mary:4:5:=contentIso:::::"
-  NAS_URL: "http://10.10.1.46:8080/"
+  NFS_SERVER_PATH: "/media/nas-mary/template/iso/baremetal"
+  NAS_URL: "https://s3.lis.mov.ai:8443/"
 
 jobs:
   Build:
@@ -209,8 +208,8 @@ jobs:
     steps:
       - name: Test NFS server
         run: |
-          if [ ! -d "$PROXMOX_NFS_SERVER_PATH" ]; then
-            echo "ERROR: NFS server path $PROXMOX_NFS_SERVER_PATH does not exist."
+          if [ ! -d "$NFS_SERVER_PATH" ]; then
+            echo "ERROR: NFS server path $NFS_SERVER_PATH does not exist."
             exit 1
           fi
 
@@ -219,28 +218,28 @@ jobs:
         run: |
           # test if inputs.manual_request is set
           if [ "${{ inputs.manual_request }}" == "true" || "${{ inputs.manual_request }}" == "True" ]; then
-            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH/${{ inputs.PRODUCT_NAME }}_${{ inputs.PRODUCT_VERSION }}_${{ needs.Build.outputs.current_version }}
+            NFS_SERVER_DEPLOY_PATH=$NFS_SERVER_PATH/${{ inputs.PRODUCT_NAME }}_${{ inputs.PRODUCT_VERSION }}_${{ needs.Build.outputs.current_version }}
           else
-            PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_PATH
+            NFS_SERVER_DEPLOY_PATH=$NFS_SERVER_PATH
           fi
-          echo "PROXMOX_NFS_SERVER_DEPLOY_PATH=$PROXMOX_NFS_SERVER_DEPLOY_PATH" >> $GITHUB_OUTPUT
+          echo "NFS_SERVER_DEPLOY_PATH=$NFS_SERVER_DEPLOY_PATH" >> $GITHUB_OUTPUT
 
 
       - name: Deploy images to NFS server
         env:
-          PROXMOX_NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.PROXMOX_NFS_SERVER_DEPLOY_PATH }}
+          NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.NFS_SERVER_DEPLOY_PATH }}
         run: |
-          sudo mkdir -p "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
-          sudo rsync --progress -z $RUN_STAGING_DIR/${{ needs.Build.outputs.file_name }} "$PROXMOX_NFS_SERVER_DEPLOY_PATH"
-          echo "Image copied to NFS server to $NAS_URL with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          sudo mkdir -p "$NFS_SERVER_DEPLOY_PATH"
+          sudo rsync --progress -z $RUN_STAGING_DIR/${{ needs.Build.outputs.file_name }} "$NFS_SERVER_DEPLOY_PATH"
+          echo "Image copied to NFS server to $NAS_URL with path $NFS_SERVER_DEPLOY_PATH"
 
       - name: Prepare slack variables
         if: always()
         id: pre_slack
         env:
-          PROXMOX_NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.PROXMOX_NFS_SERVER_DEPLOY_PATH }}
+          NFS_SERVER_DEPLOY_PATH: ${{ steps.compute_nfs_folder.outputs.NFS_SERVER_DEPLOY_PATH }}
         run: |
-          deploy_msg="Image copied to NFS server to $NAS_URL:\n\t with path $PROXMOX_NFS_SERVER_DEPLOY_PATH"
+          deploy_msg="Image copied to NFS server to $NAS_URL:\n\t with path $NFS_SERVER_DEPLOY_PATH"
           if [ "${{ inputs.manual_request }}" == "true" ] || [ "${{ inputs.manual_request }}" == "True" ]; then
             MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:\n\n${deploy_msg}"
             MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -257,22 +256,22 @@ jobs:
           summary_message="${{ steps.pre_slack.outputs.msg }}"
           echo -e "${summary_message}" >> $GITHUB_STEP_SUMMARY
 
-      # - name: Slack message success
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     channel-id: ${{ inputs.slack_channel }}
-      #     slack-message: ${{ steps.pre_slack.outputs.msg }}
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
+      - name: Slack message success
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: ${{ inputs.slack_channel }}
+          slack-message: ${{ steps.pre_slack.outputs.msg }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
-      # - name: Slack message failure
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     channel-id: ${{ inputs.slack_channel }}
-      #     slack-message: ${{ steps.pre_slack.outputs.msg_error }}
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
+      - name: Slack message failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: ${{ inputs.slack_channel }}
+          slack-message: ${{ steps.pre_slack.outputs.msg_error }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Slack message success
         uses: slackapi/slack-github-action@v1.25.0
-        if: "success() && ${{ inputs.slack_channel }}"
+        if: ${{ success() && inputs.slack_channel }}
         with:
           channel-id: ${{ inputs.slack_channel }}
           slack-message: ${{ steps.pre_slack.outputs.msg }}
@@ -282,7 +282,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
       - name: Slack message failure
-        if: "failure() && ${{ inputs.slack_channel }}"
+        if: ${{ failure() &&  inputs.slack_channel }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: ${{ inputs.slack_channel }}

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -109,12 +109,22 @@ jobs:
           sed -i 's/PRODUCT_TYPE=.*/PRODUCT_TYPE=${{ inputs.PRODUCT_TYPE }}/' config.cfg
           sed -i 's/PRODUCT_NAME=.*/PRODUCT_NAME=${{ inputs.PRODUCT_NAME }}/' config.cfg
           sed -i 's/PRODUCT_VERSION=.*/PRODUCT_VERSION=${{ inputs.PRODUCT_VERSION }}/' config.cfg
+          sed -i 's/PRODUCT_JSON_NAME=.*/PRODUCT_JSON_NAME=${{ inputs.PRODUCT_JSON_NAME }}/' config.cfg
           # test if PRODUCT_PACKAGES is set
           if [ -z "${{ inputs.PRODUCT_PACKAGES }}" ]; then
             sed -i 's/PRODUCT_PACKAGES=.*/PRODUCT_PACKAGES=none/' config.cfg
           else
             sed -i 's/PRODUCT_PACKAGES=.*/PRODUCT_PACKAGES=${{ inputs.PRODUCT_PACKAGES }}/' config.cfg
           fi
+
+      - name: Fetch release configuration files
+        run: |
+          mkdir -p offline_install_artifacts/json
+          gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "*.json" -D offline_install_artifacts/json
+        env:
+          PRODUCT_NAME: "${{ inputs.PRODUCT_NAME }}"
+          PRODUCT_VERSION: "${{ inputs.PRODUCT_VERSION }}"
+          GITHUB_TOKEN: ${{ secrets.auto_commit_pwd }}
 
       - name: Fetch platform artifacts
         run: |
@@ -130,16 +140,6 @@ jobs:
           GITHUB_API_PWD: ${{ secrets.auto_commit_pwd }}
           PRODUCT_NAME: ${{ inputs.PRODUCT_NAME }}
           PRODUCT_VERSION: ${{ inputs.PRODUCT_VERSION }}
-
-      - name: Fetch release json configuration file
-        run: |
-          mkdir -p offline_install_artifacts/json
-          gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "$PRODUCT_JSON_NAME" -D offline_install_artifacts/json
-        env:
-          PRODUCT_NAME: "${{ inputs.PRODUCT_NAME }}"
-          PRODUCT_VERSION: "${{ inputs.PRODUCT_VERSION }}"
-          PRODUCT_JSON_NAME: "${{ inputs.PRODUCT_JSON_NAME }}"
-          GITHUB_TOKEN: ${{ secrets.auto_commit_pwd }}
 
       - name: Run the script
         run: |

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Slack message success
         uses: slackapi/slack-github-action@v1.25.0
-        if: ${{ inputs.slack_channel }}
+        if: "success() && ${{ inputs.slack_channel }}"
         with:
           channel-id: ${{ inputs.slack_channel }}
           slack-message: ${{ steps.pre_slack.outputs.msg }}
@@ -268,7 +268,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
       - name: Slack message failure
-        if: failure() && ${{ inputs.slack_channel }}
+        if: "failure() && ${{ inputs.slack_channel }}"
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: ${{ inputs.slack_channel }}

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -243,7 +243,7 @@ jobs:
           if [ "${{ inputs.manual_request }}" == "true" ] || [ "${{ inputs.manual_request }}" == "True" ]; then
             MESSAGE=":arrow_forward: New version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} image available :sunny:\n\n${deploy_msg}"
             MESSAGE_ERR=":x: Build of version ${{ needs.Build.outputs.raised_version }} of ${{ inputs.PRODUCT_NAME }}:${{ inputs.PRODUCT_VERSION}} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          else:
+          else
             MESSAGE=":arrow_forward: New pre-version ${{ needs.Build.outputs.raised_version }} of baremetal image available :sunny:\n\n${deploy_msg}"
             MESSAGE_ERR=":x: Build of pre-version ${{ needs.Build.outputs.raised_version }} is unstable :rain_cloud: Details: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi

--- a/.github/workflows/offline-install-workflow-iso.yml
+++ b/.github/workflows/offline-install-workflow-iso.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Fetch release json configuration file
         run: |
           mkdir -p offline_install_artifacts/json
-          gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "$PRODUCT_JSON_NAME" -d offline_install_artifacts/json
+          gh release download -R "https://github.com/MOV-AI/$PRODUCT_NAME" "$PRODUCT_VERSION" -p "$PRODUCT_JSON_NAME" -D offline_install_artifacts/json
         env:
           PRODUCT_NAME: "project-${{ inputs.PRODUCT_NAME }}"
           PRODUCT_VERSION: "${{ inputs.PRODUCT_VERSION }}"


### PR DESCRIPTION
## content

- allow the workflow to be triggered with a manual request
- review vars and messages
- lint all .sh and .bash scripts
- deployment is different if manually triggered or  from a PR:
   - if made from a PR: default parameters from `config.cfg` file of the repository are used, destination is /template/iso/baremetal/filename.iso
   - if made from a manual request: parameters are the ones inputted , destination is /template/iso/baremetal/<product_name>-<product_version>_<template_version>.iso

See:
![image](https://github.com/user-attachments/assets/48e1a233-cb2a-4cd3-a8a4-2b1bcdbfa65c)


## test
- PR execution: https://github.com/MOV-AI/devops-iso-img/pull/8
- Manual execution: https://github.com/MOV-AI/devops-iso-img/actions/workflows/DeployOnRequest.yml

