### PR TITLE
Raise on PR (without push) so that we can avoid any bump2version issues

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -159,7 +159,6 @@ jobs:
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
     - name: Raise version
-      if: ${{ inputs.deploy == 'true' }}
       run: bump2version build setup.py --no-tag --no-commit
 
     - name: Find Package details
@@ -176,7 +175,6 @@ jobs:
 
     - name: Commit auto raise version
       id: raise
-      if: ${{ inputs.deploy == 'true' }}
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name ${{ secrets.auto_commit_user }}


### PR DESCRIPTION
I've faced this issue https://github.com/MOV-AI/message-server/commit/d1c70ad1cf52fc9c1dc902d818e5dfee7739bf2c#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R11 after a merge to main

If the bump is done also on PR, this could have been caught before merging