### PR TITLE
Proposal to modernize python pipeline

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -4,21 +4,16 @@ on:
     inputs:
       deploy:
         required: false
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
       release:
         required: false
-        type: string
-        default: 'false'
-      skip_linting:
-        required: false
-        type: string
-        default: 'false'
-        description: DEPRECATED - to be removed on v2
+        type: boolean
+        default: false
       run_black:
         required: false
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
         description: When 'true' black is run stopping the pipeline if any files are not properly formatted
       with_docs:
         required: false
@@ -51,7 +46,7 @@ on:
 
 jobs:
   RefreshSource:
-    if: ${{ inputs.deploy == 'false' }}
+    if: ${{ ! inputs.deploy }}
     runs-on: ubuntu-20.04
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
@@ -60,7 +55,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.auto_commit_password }}'
           MERGE_MSG: "Branch was auto-updated."
   Build:
-    if: ${{ inputs.release == 'false' }}
+    if: ${{ ! inputs.release }}
     runs-on: ubuntu-20.04
     container:
       image: registry.aws.cloud.mov.ai/devops/py-buildserver:latest
@@ -86,7 +81,7 @@ jobs:
       run: python3 -m pip install .
 
     - name: Run Black
-      if: ${{ inputs.run_black == 'true' }}
+      if: ${{ inputs.run_black }}
       run: |
         python3 -m black \
           --line-length 100 \
@@ -159,7 +154,7 @@ jobs:
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
     - name: Raise version
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       run: bump2version build setup.py --no-tag --no-commit
 
     - name: Find Package details
@@ -176,7 +171,7 @@ jobs:
 
     - name: Commit auto raise version
       id: raise
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name ${{ secrets.auto_commit_user }}
@@ -187,14 +182,14 @@ jobs:
         git commit -m "[skip actions] Automatic Bump of build version"
 
     - name: Set branch output
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       id: var_branch
       run: |
         echo "Branch name is: ${GITHUB_REF#refs/heads/}"
         echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
 
     - name: Raise App version
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       uses: CasperWA/push-protected@v2.14.0
       with:
         token: ${{ secrets.auto_commit_password }}
@@ -202,7 +197,7 @@ jobs:
         unprotect_reviews: true
 
     - name: Commit of version
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       id: commit_id
       run: |
         commit_hash=$(git log --format="%H" -n 1)
@@ -239,14 +234,14 @@ jobs:
         VERSION=${GITHUB_REF##*/} tox -e docs
 
     - name: Checkout gh-pages
-      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
+      if: ${{ inputs.deploy && inputs.with_docs }}
       uses: actions/checkout@v3
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Push docs
-      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
+      if: ${{ inputs.deploy && inputs.with_docs }}
       run: |
         cd gh-pages
 
@@ -274,7 +269,7 @@ jobs:
         git push --force --set-upstream origin gh-pages
 
     - name: Publish package to TestPyPI Integration
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       uses: pypa/gh-action-pypi-publish@v1.11.0
       with:
         user: ${{ secrets.nexus_publisher_user }}
@@ -282,7 +277,7 @@ jobs:
         repository-url: https://artifacts.aws.cloud.mov.ai/repository/pypi-integration/
 
     - name: Create Github Release
-      if: ${{ inputs.deploy == 'true' }}
+      if: ${{ inputs.deploy }}
       shell: bash
       run: |
         title="Release of ${{ steps.releasevars.outputs.py_pkg_version }}"
@@ -310,7 +305,7 @@ jobs:
     strategy:
       matrix:
         publish_repo: ${{ fromJSON(inputs.prod_publish_repos) }}
-    if: ${{ inputs.release == 'true' }}
+    if: ${{ inputs.release }}
     runs-on: ubuntu-20.04
     container:
       image: registry.aws.cloud.mov.ai/devops/py-buildserver:latest

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -197,7 +197,7 @@ jobs:
       id: var_branch
       run: |
         echo "Branch name is: ${GITHUB_REF#refs/heads/}"
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+        echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
     - name: Raise App version
       if: ${{ inputs.deploy }}
@@ -212,7 +212,7 @@ jobs:
       id: commit_id
       run: |
         commit_hash=$(git log --format="%H" -n 1)
-        echo ::set-output name=commit_id::$commit_hash
+        echo "commit_id=${commit_hash}" >> $GITHUB_OUTPUT
 
     - name: build
       run: python3 -m build
@@ -321,7 +321,7 @@ jobs:
 
     - name: Set tag output
       id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     - name: Fetch artifact from github release
       run: |

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -155,7 +155,11 @@ jobs:
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
     - name: Raise version
-      run: bump-my-version bump build --no-tag --no-commit
+      run: |
+        python3 -m venv venv --clear
+        . venv/bin/activate
+        pip install bump-my-version==0.29.0
+        bump-my-version bump build --no-tag --no-commit
 
     - name: Commit auto raise version
       id: raise

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -1,0 +1,351 @@
+name: Build and pack py packages
+on:
+  workflow_call:
+    inputs:
+      deploy:
+        required: false
+        type: string
+        default: 'false'
+      release:
+        required: false
+        type: string
+        default: 'false'
+      skip_linting:
+        required: false
+        type: string
+        default: 'false'
+        description: DEPRECATED - to be removed on v2
+      run_black:
+        required: false
+        type: string
+        default: 'false'
+        description: When 'true' black is run stopping the pipeline if any files are not properly formatted
+      with_docs:
+        required: false
+        type: boolean
+        default: false
+        description: When true documentation is published, the branch gh-pages must be created manually 'git checkout --orphan gh-pages && touch .nojekyll && git add .nojekyll && git commit -m "Initial commit" && git push --set-upstream origin gh-pages'
+      prod_publish_repos:
+        required: false
+        type: string
+        default: '["pypi-edge"]'
+    secrets:
+      auto_commit_user:
+        required: false # only when deploy true
+      auto_commit_mail:
+        required: false # only when deploy true
+      auto_commit_password:
+        required: false
+      registry_user:
+        required: true
+      registry_password:
+        required: true
+      nexus_publisher_user:
+        required: true
+      nexus_publisher_password:
+        required: true
+      gh_token:
+        required: true
+      sonar_token:
+        required: true
+
+jobs:
+  RefreshSource:
+    if: ${{ inputs.deploy == 'false' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.auto_commit_password }}'
+          MERGE_MSG: "Branch was auto-updated."
+  Build:
+    if: ${{ inputs.release == 'false' }}
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.aws.cloud.mov.ai/devops/py-buildserver:latest
+      credentials:
+        username: ${{secrets.registry_user}}
+        password: ${{secrets.registry_password}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        # Disabling shallow clone is recommended for improving relevancy of reporting
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Upgrade pip
+      run: python3 -m pip install pip --upgrade
+
+    - name: Install build-requirements
+      run: python3 -m pip install -r build-requirements.txt
+
+    - name: Install python package
+      run: python3 -m pip install .
+
+    - name: Run Black
+      if: ${{ inputs.run_black == 'true' }}
+      run: |
+        python3 -m black \
+          --line-length 100 \
+          --diff \
+          --check \
+          .
+
+    - name: Python Linters
+      # run linters isolated so no issues are masked from SonarCloud
+      run: |
+        python3 -m flake8 \
+          --isolated \
+          --exclude dist,.*\.egg-info,.git,__pycache__,.tox,venv \
+          --max-complexity 10 \
+          --max-line-length 100 \
+          --exit-zero \
+          --output-file flake8-report.txt
+
+        # pylint seems to not have a way to ignore configuration files
+        # so we need to provide it a dummy one
+        touch dummy-pylint-config
+        python3 -m pylint \
+          --rcfile dummy-pylint-config \
+          --ignore-patterns dist,.*\.egg-info,.git,__pycache__,.tox,venv \
+          --max-line-length 100 \
+          --exit-zero \
+          --output pylint-report.txt \
+          .
+
+    - name: Run tests
+      run: |
+        if [ -f tox.ini ]; then
+            # run tests and generates coverage.xml
+            tox
+        else
+            # run tests
+            python3 -m pytest tests/
+        fi
+
+    - name: Create SonarCloud project and disable autoscan
+      uses: MOV-AI/action-sonarcloud-proj-config@v1
+      with:
+        sonar_org: 'mov-ai'
+        sonar_token: ${{ secrets.sonar_token }}
+
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@v2.0.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.sonar_token }}
+      with:
+        projectBaseDir: ./
+        args: >
+          -Dsonar.organization=mov-ai
+          -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+          -Dsonar.sources=.
+          -Dsonar.scm.provider=git
+          -Dsonar.qualitygate.wait=true
+          -Dsonar.qualitygate.timeout=300
+          -Dsonar.coverage.exclusions=tests/**,docs/**
+          -Dsonar.cpd.exclusions=tests/**,docs/**
+          -Dsonar.python.version=3
+          -Dsonar.python.flake8.reportPaths=flake8-report.txt
+          -Dsonar.python.pylint.reportPaths=pylint-report.txt
+          -Dsonar.python.coverage.reportPaths=coverage.xml
+
+    - name: Link to SonarCloud dashboard
+      shell: bash
+      run: |
+        echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
+
+    - name: Raise version
+      if: ${{ inputs.deploy == 'true' }}
+      run: bump2version build setup.py --no-tag --no-commit
+
+    - name: Find Package details
+      id: vars
+      run: |
+        PACKAGE_VERSION=$(cat .bumpversion.cfg | sed s/' '/''/g | grep 'current_version=' | sed s/'current_version='/''/g)
+        PACKAGE_NAME=$(cat setup.py | grep name | cut -d '"' -f2)
+
+        echo ::set-output name=py_pkg_name::$PACKAGE_NAME
+        echo ::set-output name=py_pkg_version::$PACKAGE_VERSION
+
+    - name: Sync setup.py
+      run: sed -i s/"$(cat setup.py | grep version=)"/"    version=\"${{ steps.vars.outputs.py_pkg_version }}\","/g setup.py
+
+    - name: Commit auto raise version
+      id: raise
+      if: ${{ inputs.deploy == 'true' }}
+      run: |
+        git config --global --add safe.directory $(pwd)
+        git config --global user.name ${{ secrets.auto_commit_user }}
+        git config --global user.email ${{ secrets.auto_commit_mail }}
+        git add setup.py
+        git add .bumpversion.cfg
+        git add **__version__.py || true
+        git commit -m "[skip actions] Automatic Bump of build version"
+
+    - name: Set branch output
+      if: ${{ inputs.deploy == 'true' }}
+      id: var_branch
+      run: |
+        echo "Branch name is: ${GITHUB_REF#refs/heads/}"
+        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+
+    - name: Raise App version
+      if: ${{ inputs.deploy == 'true' }}
+      uses: CasperWA/push-protected@v2.14.0
+      with:
+        token: ${{ secrets.auto_commit_password }}
+        branch: ${{ steps.var_branch.outputs.branch }}
+        unprotect_reviews: true
+
+    - name: Commit of version
+      if: ${{ inputs.deploy == 'true' }}
+      id: commit_id
+      run: |
+        commit_hash=$(git log --format="%H" -n 1)
+        echo ::set-output name=commit_id::$commit_hash
+
+    - name: Enable 4 digit version
+      id: releasevars
+      run: |
+        PACKAGE_RELEASE_VERSION=$(echo ${{ steps.vars.outputs.py_pkg_version }} | sed s/"-"/"."/g)
+        sed -i s/"$(cat setup.py | grep version=)"/"$(cat setup.py | grep version= | sed s/"-"/"."/g)"/g setup.py
+
+        echo ::set-output name=py_pkg_version::$PACKAGE_RELEASE_VERSION
+
+    - name: build
+      run: python3 -m build
+
+    - name: Archive binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: dist/*
+        retention-days: 5
+
+    - name: Publish package to TestPyPI Experimental
+      uses: pypa/gh-action-pypi-publish@v1.11.0
+      with:
+        user: ${{ secrets.nexus_publisher_user }}
+        password: ${{ secrets.nexus_publisher_password }}
+        repository-url: https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/
+
+    - name: Build docs
+      if: ${{ inputs.with_docs }}
+      run: |
+        VERSION=${GITHUB_REF##*/} tox -e docs
+
+    - name: Checkout gh-pages
+      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
+      uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Push docs
+      if: ${{ inputs.deploy == 'true' && inputs.with_docs }}
+      run: |
+        cd gh-pages
+
+        # create .nojekyll
+        touch .nojekyll
+
+        # delete old folder if existed
+        rm -rf ${GITHUB_REF##*/}
+
+        # copy new docs and root index.html
+        cp -r ../docs/build/* .
+
+        # update versions.json
+        ls -mQd */ | sed 's/\///g' | sed 's/^/[/' | sed 's/$/]/' > versions.json
+
+        # set user
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+
+        # commit docs
+        git add .
+        git commit -am "Updating docs for commit ${GITHUB_SHA} in ${GITHUB_REF}"
+
+        # overwrite the contents of the gh-pages branch on our github.com repo
+        git push --force --set-upstream origin gh-pages
+
+    - name: Publish package to TestPyPI Integration
+      if: ${{ inputs.deploy == 'true' }}
+      uses: pypa/gh-action-pypi-publish@v1.11.0
+      with:
+        user: ${{ secrets.nexus_publisher_user }}
+        password: ${{ secrets.nexus_publisher_password }}
+        repository-url: https://artifacts.aws.cloud.mov.ai/repository/pypi-integration/
+
+    - name: Create Github Release
+      if: ${{ inputs.deploy == 'true' }}
+      shell: bash
+      run: |
+        title="Release of ${{ steps.releasevars.outputs.py_pkg_version }}"
+        git config --global --add safe.directory $(pwd)
+
+        gh release create -p -t "$title" -n "Release notes for ${{ steps.vars.outputs.py_pkg_name }}" \
+        --target ${{ steps.commit_id.outputs.commit_id }} \
+        --generate-notes \
+        ${{ steps.releasevars.outputs.py_pkg_version }}
+
+        # add all files in the artifacts folder
+        assets=()
+        for asset in dist/*; do
+          # do nothing if folder is empty
+          if [[ $asset != "dist/*" ]]; then
+            gh release upload ${{ steps.releasevars.outputs.py_pkg_version }} $asset
+          fi
+        done
+
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+
+  Release:
+    strategy:
+      matrix:
+        publish_repo: ${{ fromJSON(inputs.prod_publish_repos) }}
+    if: ${{ inputs.release == 'true' }}
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.aws.cloud.mov.ai/devops/py-buildserver:latest
+      credentials:
+        username: ${{secrets.registry_user}}
+        password: ${{secrets.registry_password}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set tag output
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+    - name: Fetch artifact from github release
+      run: |
+        git config --global --add safe.directory $(pwd)
+        mkdir dist
+        cd dist
+        gh release download ${{ steps.vars.outputs.tag}} -p *.whl
+        gh release download ${{ steps.vars.outputs.tag}} -p *.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+    - name: Archive binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: dist/*
+        retention-days: 5
+
+    - name: Publish package to ${{ matrix.publish_repo }}
+      uses: pypa/gh-action-pypi-publish@v1.11.0
+      with:
+        user: ${{ secrets.nexus_publisher_user }}
+        password: ${{ secrets.nexus_publisher_password }}
+        repository-url: https://artifacts.aws.cloud.mov.ai/repository/${{ matrix.publish_repo }}/

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
@@ -317,7 +317,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set tag output
       id: vars

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -152,7 +152,7 @@ jobs:
         sonar_token: ${{ secrets.sonar_token }}
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@v2.0.2
+      uses: SonarSource/sonarqube-scan-action@v4.2.1
       env:
         GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.sonar_token }}

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      pre_commit:
+        required: false
+        type: boolean
+        default: false
       run_black:
         required: false
         type: boolean
@@ -54,6 +58,25 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.auto_commit_password }}'
           MERGE_MSG: "Branch was auto-updated."
+
+  Pre-commit:
+    if: ${{ inputs.pre_commit }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies and package
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple -r build-requirements.txt
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple .
+
+          python3 -m pip install pre-commit
+
+      - name: Run pre-commit
+        run: |
+          python3 -m pre_commit run --show-diff-on-failure --color=always --all-files
 
   Build:
     if: ${{ ! inputs.release }}

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.auto_commit_password }}'
           MERGE_MSG: "Branch was auto-updated."
+
   Build:
     if: ${{ ! inputs.release }}
     runs-on: ubuntu-20.04
@@ -154,32 +155,15 @@ jobs:
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
     - name: Raise version
-      if: ${{ inputs.deploy }}
-      run: bump2version build setup.py --no-tag --no-commit
-
-    - name: Find Package details
-      id: vars
-      run: |
-        PACKAGE_VERSION=$(cat .bumpversion.cfg | sed s/' '/''/g | grep 'current_version=' | sed s/'current_version='/''/g)
-        PACKAGE_NAME=$(cat setup.py | grep name | cut -d '"' -f2)
-
-        echo ::set-output name=py_pkg_name::$PACKAGE_NAME
-        echo ::set-output name=py_pkg_version::$PACKAGE_VERSION
-
-    - name: Sync setup.py
-      run: sed -i s/"$(cat setup.py | grep version=)"/"    version=\"${{ steps.vars.outputs.py_pkg_version }}\","/g setup.py
+      run: bump-my-version bump build --no-tag --no-commit
 
     - name: Commit auto raise version
       id: raise
-      if: ${{ inputs.deploy }}
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name ${{ secrets.auto_commit_user }}
         git config --global user.email ${{ secrets.auto_commit_mail }}
-        git add setup.py
-        git add .bumpversion.cfg
-        git add **__version__.py || true
-        git commit -m "[skip actions] Automatic Bump of build version"
+        git commit -am "[skip actions] Automatic Bump of build version to ${{ steps.bump.outputs.current-version }}"
 
     - name: Set branch output
       if: ${{ inputs.deploy }}
@@ -202,14 +186,6 @@ jobs:
       run: |
         commit_hash=$(git log --format="%H" -n 1)
         echo ::set-output name=commit_id::$commit_hash
-
-    - name: Enable 4 digit version
-      id: releasevars
-      run: |
-        PACKAGE_RELEASE_VERSION=$(echo ${{ steps.vars.outputs.py_pkg_version }} | sed s/"-"/"."/g)
-        sed -i s/"$(cat setup.py | grep version=)"/"$(cat setup.py | grep version= | sed s/"-"/"."/g)"/g setup.py
-
-        echo ::set-output name=py_pkg_version::$PACKAGE_RELEASE_VERSION
 
     - name: build
       run: python3 -m build
@@ -280,26 +256,25 @@ jobs:
       if: ${{ inputs.deploy }}
       shell: bash
       run: |
-        title="Release of ${{ steps.releasevars.outputs.py_pkg_version }}"
+        title="Release of ${{ steps.bump.outputs.current-version }}"
         git config --global --add safe.directory $(pwd)
 
-        gh release create -p -t "$title" -n "Release notes for ${{ steps.vars.outputs.py_pkg_name }}" \
+        gh release create -p -t "$title" -n "Release notes for ${{ github.event.repository.name }}" \
         --target ${{ steps.commit_id.outputs.commit_id }} \
         --generate-notes \
-        ${{ steps.releasevars.outputs.py_pkg_version }}
+        ${{ steps.bump.outputs.current-version }}
 
         # add all files in the artifacts folder
         assets=()
         for asset in dist/*; do
           # do nothing if folder is empty
           if [[ $asset != "dist/*" ]]; then
-            gh release upload ${{ steps.releasevars.outputs.py_pkg_version }} $asset
+            gh release upload ${{ steps.bump.outputs.current-version }} $asset
           fi
         done
 
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
-
 
   Release:
     strategy:


### PR DESCRIPTION
- [BP-1329](https://movai.atlassian.net/browse/BP-1329): Proposal to modernize python pipeline

## Why?
I've been looking into modernizing the way we setup our Python packages, namely to move away from `setup.py` to use the standard `pyproject.toml`.
Our current pipeline relies on `setup.py` to exist, so this proposal uses tools which rely on `pyproject.toml`.

## What changes?
1. Convert parameters from string to boolean and remove deprecated ones
2. Migrate from [bump2version](https://github.com/c4urself/bump2version) to [bump-my-version](https://github.com/callowayproject/bump-my-version) (bump2version is deprecated)
3. Remove references to setup.py
4. Optionally run pre-commit
5. Use checkout@v4
6. Use GITHUB_OUTPUT syntax

## Tests?
Currently being tested in https://github.com/MOV-AI/backend/pull/241

[BP-1329]: https://movai.atlassian.net/browse/BP-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ