### PR TITLE
Fix to freeze Ubuntu Version

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -121,7 +121,7 @@ env:
 
 jobs:
   Compute-timeout:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       timeout: ${{ steps.Compute-timeout.outputs.timeout }}
       jobtimeout: ${{ steps.Compute-timeout.outputs.jobtimeout }}

--- a/.github/workflows/packer-workflow-img.yml
+++ b/.github/workflows/packer-workflow-img.yml
@@ -62,7 +62,7 @@ jobs:
           MERGE_MSG: "Branch was auto-updated."
 
   Validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ inputs.release == 'false' }}
     steps:
       - name: Checkout

--- a/.github/workflows/packer-workflow-img.yml
+++ b/.github/workflows/packer-workflow-img.yml
@@ -53,7 +53,7 @@ jobs:
 
   RefreshSource:
     if: ${{ inputs.deploy == 'false' && inputs.release == 'false' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         continue-on-error: true
@@ -138,7 +138,7 @@ jobs:
           mv -f ./output/${{ matrix.image_type }} $RUN_STAGING_DIR
 
   Create-Release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: Build
     if: ${{ inputs.deploy == 'true' && inputs.release == 'false' }}
     steps:
@@ -289,7 +289,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_ID }}
 
   Write-Build-Summary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ Build, Create-Release, Deploy-Images ]
     if: ${{ inputs.release == 'false' }}
     steps:
@@ -301,7 +301,7 @@ jobs:
           echo -e "### Build Summary\n${summary_message}" >> $GITHUB_STEP_SUMMARY
 
   Write-Release-Summary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ Release-Images ]
     if: ${{ inputs.release == 'true' }}
     steps:

--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -56,7 +56,7 @@ jobs:
           deactivate
 
   Validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes
- packer pipeline uses Ubuntu 22.04 instead of latest /24.04)
- build-product and qa-ui workflow were also using latest , so freezing it to 22.04