### PR TITLE
Update gh-action-pypi-publish

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -246,7 +246,7 @@ jobs:
         retention-days: 5
 
     - name: Publish package to TestPyPI Experimental
-      uses: pypa/gh-action-pypi-publish@v1.11.0
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         user: ${{ secrets.nexus_publisher_user }}
         password: ${{ secrets.nexus_publisher_password }}

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -89,11 +89,6 @@ jobs:
   Build:
     if: ${{ ! inputs.release }}
     runs-on: ubuntu-20.04
-    container:
-      image: registry.aws.cloud.mov.ai/devops/py-buildserver:latest
-      credentials:
-        username: ${{secrets.registry_user}}
-        password: ${{secrets.registry_password}}
 
     steps:
     - name: Checkout
@@ -109,6 +104,17 @@ jobs:
 
     - name: Upgrade pip
       run: python -m pip install pip --upgrade
+
+    - name: Configure pip with custom index
+      run: |
+        mkdir -p ~/.config/pip
+        echo "[global]" > ~/.config/pip/pip.conf
+        echo "index-url = https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple" >> ~/.config/pip/pip.conf
+        echo "extra-index-url =" >> ~/.config/pip/pip.conf
+        echo "  https://pypi.org/simple" >> ~/.config/pip/pip.conf
+        echo "trusted-host =" >> ~/.config/pip/pip.conf
+        echo "  artifacts.cloud.mov.ai" >> ~/.config/pip/pip.conf
+        echo "  pypi.org" >> ~/.config/pip/pip.conf
 
     - name: Install build-requirements
       run: python -m pip install -r build-requirements.txt


### PR DESCRIPTION
Upgrade needed to support packages with Metadata 2.4. the lack of which is breaking pipelines: https://github.com/MOV-AI/message-server/actions/runs/14039106207/job/39304483073
