### PR TITLE
Fix: Force vm provisiong to be sequential

### DIFF
--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -1029,7 +1029,7 @@ jobs:
     strategy:
       matrix:
         distro: ${{ fromJSON(inputs.ros_distro) }}
-    runs-on: integration-pipeline-hel0
+    runs-on: ip-hel0-queuer
     container:
       image: registry.aws.cloud.mov.ai/qa/py-buildserver:v3.0.3
       credentials:
@@ -1427,7 +1427,7 @@ jobs:
     strategy:
       matrix:
         distro: ${{ fromJSON(inputs.ros_distro) }}
-    runs-on: integration-pipeline-hel0
+    runs-on: ip-hel0-queuer
     container:
       image: registry.aws.cloud.mov.ai/qa/py-buildserver:v3.0.3
       credentials:


### PR DESCRIPTION
- Move provisioning of vms into hel0 queuer label (which corresponds to the queuer and the infra-runner machine)

Test: https://github.com/MOV-AI/project-composite-tugger-palletmover/actions/runs/14245137962/job/39925369537