### PR TITLE
Qap 4663 save test logs like api tests do

### DIFF
--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -125,7 +125,8 @@ jobs:
           pytest \
             --hub_url ${{ inputs.selenoid_server_url }} \
             --base_url https://${{ steps.agent_info.outputs.ip }}/ \
-            --install-platform
+            --install-platform \
+            | tee tests_logs.txt
 
       - name: Save docker container logs
         if: always()

--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -126,7 +126,7 @@ jobs:
             --hub_url ${{ inputs.selenoid_server_url }} \
             --base_url https://${{ steps.agent_info.outputs.ip }}/ \
             --install-platform \
-            | tee /tests_artifacts/tests_logs.txt
+            | tee pytest-output.log
 
       - name: Save docker container logs
         if: always()

--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -126,7 +126,7 @@ jobs:
             --hub_url ${{ inputs.selenoid_server_url }} \
             --base_url https://${{ steps.agent_info.outputs.ip }}/ \
             --install-platform \
-            | tee tests_logs.txt
+            | tee /tests_artifacts/tests_logs.txt
 
       - name: Save docker container logs
         if: always()


### PR DESCRIPTION
Create file with tests output from the terminal so we dont need the github action to discuss issues.