### PR TITLE
Fix DP-1855 : clean repository from invalid package.xml files

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -145,11 +145,7 @@ jobs:
 
     - name: Clean repository from invalid package.xml files
       run: |
-        python3 -m venv /tmp/catkin_lint_venv
-        source /tmp/catkin_lint_venv/bin/activate
-        pip install --upgrade pip
-        pip install catkin_lint
-
+        python3 -m pip install catkin_lint --quiet --no-cache-dir
         echo "Identifying and removing package.xml files that cause internal errors in catkin_lint..."
         pkg_xml_files=$(find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null)
         for file in $pkg_xml_files; do
@@ -160,9 +156,6 @@ jobs:
             rm "$file"
           fi
         done
-
-        deactivate
-        rm -rf /tmp/catkin_lint_venv
 
     - name: Install Mobros
       run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -161,9 +161,7 @@ jobs:
           fi
         done
 
-        # Deactivate and remove the virtual environment
         deactivate
-        echo "Cleaning up temporary virtual environment..."
         rm -rf /tmp/catkin_lint_venv
 
     - name: Install Mobros

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -116,6 +116,20 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Clean repository from invalid package.xml files
+      run: |
+        python3 -m pip install catkin_lint --quiet --no-cache-dir
+        echo "Identifying and removing package.xml files that cause internal errors in catkin_lint..."
+        pkg_xml_files=$(find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null)
+        for file in $pkg_xml_files; do
+          pkg_dir=$(dirname "$file")
+          output=$(catkin_lint --quiet $pkg_dir 2>&1) || true
+          if echo "$output" | grep -q "internal error"; then
+            rm -vf "$file"
+            echo "::warning file=$file::Removed package.xml that causes internal errors"
+          fi
+        done
+
     - name: Validate Repository Package.xml
       run: |
         expected_url="<url>$GITHUB_SERVER_URL/$GITHUB_REPOSITORY</url>"
@@ -131,7 +145,7 @@ jobs:
           if [ -z "$search_result" ]:
           then
               echo "\e[31m$0"
-              touch $2
+              echo "$0" >> $2
           fi
         fi
 
@@ -140,22 +154,16 @@ jobs:
         if [ -f $VALIDATION_FILE ];
         then
             echo "\e[31mPlease add \033[0;36m$expected_url \e[31mto all the package.xmls mentioned above!"
+            # add a comment to the PR if it exists
+            if [ -n "$GITHUB_EVENT_PATH" ]; then
+                pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+                if [ -n "$pr_number" ]; then
+                    bad_files=$(cat $VALIDATION_FILE)
+                    gh pr comment "$pr_number" --body "The following package.xml files are missing the required URL tag:\n\n$bad_files\n\nPlease add the URL tag to these files." || true
+                fi
+            fi
             exit 1
         fi
-
-    - name: Clean repository from invalid package.xml files
-      run: |
-        python3 -m pip install catkin_lint --quiet --no-cache-dir
-        echo "Identifying and removing package.xml files that cause internal errors in catkin_lint..."
-        pkg_xml_files=$(find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null)
-        for file in $pkg_xml_files; do
-          pkg_dir=$(dirname "$file")
-          output=$(catkin_lint --quiet $pkg_dir 2>&1) || true
-          if [[ "$output" == *"internal error"* ]]; then
-            echo "Removing package.xml that causes internal errors: $file"
-            rm "$file"
-          fi
-        done
 
     - name: Install Mobros
       run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -155,7 +155,10 @@ jobs:
 
         if [ -f $VALIDATION_FILE ];
         then
-            echo "::error file=$VALIDATION_FILE::Please add $expected_url to all the package.xmls:\n $(cat $VALIDATION_FILE)"
+            echo "::error Validation failed::The following package.xml files are missing the URL tag"
+            for file in $(cat $VALIDATION_FILE); do
+                echo "::error file=$file::Please add $expected_url to the package.xml"
+            done
             exit 1
         fi
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -156,7 +156,7 @@ jobs:
             echo "\e[31mPlease add \033[0;36m$expected_url \e[31mto all the package.xmls mentioned above!"
             # add a comment to the PR if it exists
             if [ -n "$GITHUB_EVENT_PATH" ]; then
-                pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+                pr_number=$(grep -o '"number":[^,}]*' "$GITHUB_EVENT_PATH" | grep -o '[0-9]\+' | head -1)
                 if [ -n "$pr_number" ]; then
                     bad_files=$(cat $VALIDATION_FILE)
                     gh pr comment "$pr_number" --body "The following package.xml files are missing the required URL tag:\n\n$bad_files\n\nPlease add the URL tag to these files." || true

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -120,10 +120,9 @@ jobs:
       run: |
         python3 -m pip install catkin_lint --quiet --no-cache-dir
         echo "Identifying and removing package.xml files that cause internal errors in catkin_lint..."
-        pkg_xml_files=$(find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null)
-        for file in $pkg_xml_files; do
+        find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null | while read -r file; do
           pkg_dir=$(dirname "$file")
-          output=$(catkin_lint --quiet $pkg_dir 2>&1) || true
+          output=$(catkin_lint --quiet "$pkg_dir" 2>&1) || true
           if echo "$output" | grep -q "internal error"; then
             rm -vf "$file"
             echo "::warning file=$file::Removed package.xml that causes internal errors"

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -142,6 +142,29 @@ jobs:
             echo "\e[31mPlease add \033[0;36m$expected_url \e[31mto all the package.xmls mentioned above!"
             exit 1
         fi
+
+    - name: Clean repository from invalid package.xml files
+      run: |
+        python3 -m venv /tmp/catkin_lint_venv
+        source /tmp/catkin_lint_venv/bin/activate
+        pip install --upgrade pip
+        pip install catkin_lint
+
+        echo "Identifying and removing package.xml files that cause internal errors in catkin_lint..."
+        pkg_xml_files=$(find -L ./ -type f -name 'package.xml' ! -path '*/.git/*' ! -path '*/.github/*' 2>/dev/null)
+        for file in $pkg_xml_files; do
+          pkg_dir=$(dirname "$file")
+          output=$(catkin_lint --quiet $pkg_dir 2>&1) || true
+          if [[ "$output" == *"internal error"* ]]; then
+            echo "Removing package.xml that causes internal errors: $file"
+            rm "$file"
+          fi
+        done
+
+        # Deactivate and remove the virtual environment
+        deactivate
+        echo "Cleaning up temporary virtual environment..."
+        rm -rf /tmp/catkin_lint_venv
 
     - name: Install Mobros
       run: |
@@ -207,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
@@ -318,7 +341,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -460,7 +483,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -131,6 +131,8 @@ jobs:
         done
 
     - name: Validate Repository Package.xml
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         expected_url="<url>$GITHUB_SERVER_URL/$GITHUB_REPOSITORY</url>"
         VALIDATION_FILE="/tmp/verification-failed"
@@ -153,15 +155,7 @@ jobs:
 
         if [ -f $VALIDATION_FILE ];
         then
-            echo "\e[31mPlease add \033[0;36m$expected_url \e[31mto all the package.xmls mentioned above!"
-            # add a comment to the PR if it exists
-            if [ -n "$GITHUB_EVENT_PATH" ]; then
-                pr_number=$(grep -o '"number":[^,}]*' "$GITHUB_EVENT_PATH" | grep -o '[0-9]\+' | head -1)
-                if [ -n "$pr_number" ]; then
-                    bad_files=$(cat $VALIDATION_FILE)
-                    gh pr comment "$pr_number" --body "The following package.xml files are missing the required URL tag:\n\n$bad_files\n\nPlease add the URL tag to these files." || true
-                fi
-            fi
+            echo "::error file=$VALIDATION_FILE::Please add $expected_url to all the package.xmls:\n $(cat $VALIDATION_FILE)"
             exit 1
         fi
 


### PR DESCRIPTION
- review ros-workflow to clean repository from invalid package.xml files
Tested ok: https://github.com/MOV-AI/movai_openzen_sensor/actions/runs/15353065620

---
**Detail info:** 
Adds a new step in the GitHub Actions workflow named "Clean repository from invalid package.xml files". This step runs a script to identify and remove invalid package.xml files that cause internal errors in the catkin_lint tool. Specifically, it:

Installs the catkin_lint Python package.
Searches recursively for package.xml files, excluding .git and .github directories.
Checks each found package.xml file for internal errors using catkin_lint.
Removes any package.xml file causing internal errors and logs a warning message indicating its removal.
This ensures that invalid package.xml files do not cause issues in the subsequent workflow steps.

**Warning:***

As it can lead to unexpected and silent failures or non-compilation, I have added a warning in the summary of the PR checks actions
![Uploading image.png…]()

