### PR TITLE
DP-1854 - Updated PROVISION_INFRA_VERSION from 2.0.0-13 to 2.0.0-14

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -123,7 +123,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-13"
+  PROVISION_INFRA_VERSION: "2.0.0-14"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -75,7 +75,7 @@ env:
   JIRA_PASSWORD: ${{ secrets.jira_password}}
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-13"
+  PROVISION_INFRA_VERSION: "2.0.0-14"
   PROVISION_INFRA_DIR: "provision_scripts"
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"


### PR DESCRIPTION
This pull request updates the `PROVISION_INFRA_VERSION` environment variable in two workflow files to use version `2.0.0-14` instead of `2.0.0-13`. 

Affected files:

- [`.github/workflows/integration-build-product.yml`](diffhunk://#diff-bfbc34c7422e454a0711853cff89419314a75ba02364b4ceb1d4ba7f278b8e2eL126-R126): Updated `PROVISION_INFRA_VERSION` to `2.0.0-14`.
- [`.github/workflows/integration-robotic-stack-tests.yml`](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL78-R78): Updated `PROVISION_INFRA_VERSION` to `2.0.0-14`.<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
