### PR TITLE
DP-1865- v2.2 - bump version provision infra to 2.0.0-15

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -105,7 +105,7 @@ env:
   # development slack channel
   #SLACK_CHANNEL: "C05K2KF1UP8"
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-14"
+  PROVISION_INFRA_VERSION: "2.0.0-15"
   PROVISIONING_ENV_VERSION: 0.1.0-17
   PROVISIONING_ENV_REPO: devops-tf-env-conf
   ARTIFACTS_RETENTION_DAYS: 15
@@ -484,7 +484,7 @@ jobs:
           docker pull "${{ env.REGISTRY }}/ci/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.REGISTRY }}/qa/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.MID_REGISTRY }}/qa/$backend_image"
-          
+
 
       - name: Install
         id: install
@@ -503,7 +503,7 @@ jobs:
           sudo rm -rf $USERSPACE_FOLDER_PATH || true
           sudo mkdir -p $USERSPACE_FOLDER_PATH
           sudo chmod 777 $USERSPACE_FOLDER_PATH
-          
+
           export PUBLIC_IP=$(hostname -I | awk '{print $1}')
           wget https://movai-scripts.s3.amazonaws.com/QuickStart_$(cat quickstart_version).bash
           chmod +x ./QuickStart_$(cat quickstart_version).bash
@@ -549,7 +549,7 @@ jobs:
             --movai-user ${{ steps.install.outputs.movai_user }} \
             --movai-pw ${{ steps.install.outputs.movai_pwd }} \
             --cucumberjson=./results.json \
-            --junit-xml=junit.xml 
+            --junit-xml=junit.xml
           deactivate
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.buildkite_token }}
@@ -815,7 +815,7 @@ jobs:
           docker pull "${{ env.REGISTRY }}/ci/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.REGISTRY }}/qa/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.MID_REGISTRY }}/qa/$backend_image"
-          
+
       - name: Install tests
         timeout-minutes: 45
         id: install
@@ -830,13 +830,13 @@ jobs:
           sudo mkdir -p $USERSPACE_FOLDER_PATH/automated_install
           sudo chmod 777 -R $USERSPACE_FOLDER_PATH
           if [ "${{ steps.install_tests_setup.outputs.jira_report }}" == "True" ] ; then
-          
+
           python3 -m pytest tests/ \
               -ra \
               -k '${{ steps.install_tests_setup.outputs.test_set }}' \
               --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" \
               --jira_report \
-              --junit-xml=junit.xml 
+              --junit-xml=junit.xml
 
           else
           python3 -m pytest tests/ \
@@ -845,7 +845,7 @@ jobs:
               --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --junit-xml=junit.xml
           fi
           deactivate
-          
+
           user=$(cat results/credentials.txt | awk -F: '{print $1}')
           pwd=$(cat results/credentials.txt | awk -F: '{print $2}')
 
@@ -1160,7 +1160,7 @@ jobs:
           deactivate
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.buildkite_token }}
-      
+
       - name: Publish test results trunk
         if: always()
         working-directory: ${{ steps.api_tests_setup.outputs.target_dir }}
@@ -1356,7 +1356,7 @@ jobs:
           docker pull "${{ env.REGISTRY }}/ci/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.REGISTRY }}/qa/$backend_image"
           docker tag "${{ env.REGISTRY }}/ci/$backend_image" "${{ env.MID_REGISTRY }}/qa/$backend_image"
-       
+
       - name: Install
         id: install
         shell: bash
@@ -1764,7 +1764,7 @@ jobs:
             ansible $fleet_host -i ../staging/provisioned_inventory.yml --key-file ~/.ssh/aws_slave.pem -m shell -a "set -e; docker tag $SOURCE_TAG $TARGET_TAG_REGISTRY"
             ansible $fleet_host -i ../staging/provisioned_inventory.yml --key-file ~/.ssh/aws_slave.pem -m shell -a "set -e; docker tag $SOURCE_TAG $TARGET_TAG_MID_REGISTRY"
           done
-          
+
 
           ansible-playbook install.yml \
             -i ../staging/provisioned_inventory.yml \
@@ -2271,7 +2271,7 @@ jobs:
             -m 'simulator' \
             --tb=short \
             --junit-xml=junit.xml
-            
+
           ./trunk flakytests upload \
             --org-url-slug "movai" \
             --token "60df2c8fa3c66877002b26c722ec2708e80d7fad" \
@@ -2487,7 +2487,7 @@ jobs:
           username: ${{ secrets.registry_user }}
           password: ${{ secrets.registry_password }}
           registry: ${{ env.REGISTRY }}
-  
+
       - name: Login to ${{ env.PUSH_REGISTRY }} Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -123,7 +123,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-14"
+  PROVISION_INFRA_VERSION: "2.0.0-15"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -75,7 +75,7 @@ env:
   JIRA_PASSWORD: ${{ secrets.jira_password}}
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-14"
+  PROVISION_INFRA_VERSION: "2.0.0-15"
   PROVISION_INFRA_DIR: "provision_scripts"
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"


### PR DESCRIPTION
This pull request updates the `PROVISION_INFRA_VERSION` environment variable across multiple GitHub workflow files to reflect the new version `2.0.0-15`. This ensures that all workflows use the latest infrastructure provisioning version.

Version updates in GitHub workflows:

* [`.github/workflows/integration-build-platform.yml`](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535L108-R108): Updated `PROVISION_INFRA_VERSION` from `2.0.0-14` to `2.0.0-15`.
* [`.github/workflows/integration-build-product.yml`](diffhunk://#diff-bfbc34c7422e454a0711853cff89419314a75ba02364b4ceb1d4ba7f278b8e2eL126-R126): Updated `PROVISION_INFRA_VERSION` from `2.0.0-14` to `2.0.0-15`.
* [`.github/workflows/integration-robotic-stack-tests.yml`](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL78-R78): Updated `PROVISION_INFRA_VERSION` from `2.0.0-14` to `2.0.0-15`.<!-- Please describe your pull request here. -->


