### PR TITLE
DP-1875: CICD: Integration build platform support overriding of robotics tests version 

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -44,7 +44,7 @@ on:
         required: false
         type: string
         default: "simulator_tests"
-      robotics_test_version:
+      simulation_qa_version:
         required: false
         type: string
         default: ""

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -48,6 +48,7 @@ on:
         required: false
         type: string
         default: ""
+        description: Version of the simulator tests to run. If not provided, the version will be taken from the product manifest.
     secrets:
       auto_commit_user:
         required: true
@@ -1000,7 +1001,7 @@ jobs:
       debug_simulation_tests_keep_alive: ${{ inputs.debug_simulation_tests_keep_alive }}
       backend_name: ${{ needs.Build-Simulator.outputs.backend_image }}
       simulation_qa_key: ${{ inputs.simulation_qa_key }}
-      robotics_test_version: ${{ inputs.robotics_test_version }}
+      simulation_qa_version: ${{ inputs.simulation_qa_version }}
 
   publish:
     needs: [Validations-Finish, Fleet-Validations, Simulator-Validations, Robotic-Stack-Integration]

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -44,6 +44,10 @@ on:
         required: false
         type: string
         default: "simulator_tests"
+      robotics_test_version:
+        required: false
+        type: string
+        default: ""
     secrets:
       auto_commit_user:
         required: true
@@ -996,6 +1000,7 @@ jobs:
       debug_simulation_tests_keep_alive: ${{ inputs.debug_simulation_tests_keep_alive }}
       backend_name: ${{ needs.Build-Simulator.outputs.backend_image }}
       simulation_qa_key: ${{ inputs.simulation_qa_key }}
+      robotics_test_version: ${{ inputs.robotics_test_version }}
 
   publish:
     needs: [Validations-Finish, Fleet-Validations, Simulator-Validations, Robotic-Stack-Integration]

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -28,7 +28,7 @@ on:
         required: false
         type: string
         default: "simulator_tests"
-      robotics_test_version:
+      simulation_qa_version:
         required: false
         type: string
         default: ""
@@ -69,7 +69,7 @@ on:
       minio_secret_key_id:
         required: true
 env:
-  CI_INTEGRATION_CONTAINER_VERSION: "registry.cloud.mov.ai/qa/ci-tools:4.0.0.31" # to update
+  CI_INTEGRATION_CONTAINER_VERSION: "registry.cloud.mov.ai/qa/ci-tools:4.0.2.1"
   CI_INTEGRATION_CONTAINER_WORKSPACE: "/opt/mov.ai/workspace"
   CI_INTEGRATION_EXECUTION_FOLDER: "$(pwd)/temp"
   GITHUB_API_USR: "OttoMation-Movai"
@@ -384,10 +384,10 @@ jobs:
 
             qa_key=${{ inputs.simulation_qa_key }}
 
-            # overwrite tests versions if version provided 
+            # override tests versions if version provided 
             override_option=""
-            if [ -n "${{ inputs.robotics_test_version }}" ]; then
-              override_option="--override_test_version ${{ inputs.robotics_test_version }}"
+            if [ -n "${{ inputs.simulation_qa_version }}" ]; then
+              override_option="--override_test_version ${{ inputs.simulation_qa_version }}"
             fi
 
             docker run -u root \

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: "simulator_tests"
+      robotics_test_version:
+        required: false
+        type: string
+        default: ""
 
     secrets:
       auto_commit_user:
@@ -65,7 +69,7 @@ on:
       minio_secret_key_id:
         required: true
 env:
-  CI_INTEGRATION_CONTAINER_VERSION: "registry.cloud.mov.ai/qa/ci-tools:4.0.0.31"
+  CI_INTEGRATION_CONTAINER_VERSION: "registry.cloud.mov.ai/qa/ci-tools:4.0.0.31" # to update
   CI_INTEGRATION_CONTAINER_WORKSPACE: "/opt/mov.ai/workspace"
   CI_INTEGRATION_EXECUTION_FOLDER: "$(pwd)/temp"
   GITHUB_API_USR: "OttoMation-Movai"
@@ -380,6 +384,12 @@ jobs:
 
             qa_key=${{ inputs.simulation_qa_key }}
 
+            # overwrite tests versions if version provided 
+            override_option=""
+            if [ -n "${{ inputs.robotics_test_version }}" ]; then
+              override_option="--override_test_version ${{ inputs.robotics_test_version }}"
+            fi
+
             docker run -u root \
               -v "${{ env.CI_INTEGRATION_EXECUTION_FOLDER }}":${{ env.CI_INTEGRATION_CONTAINER_WORKSPACE }} \
               -i ${{ env.CI_INTEGRATION_CONTAINER_VERSION }} \
@@ -387,7 +397,7 @@ jobs:
               --file product-manifest.yaml \
               --key product_components.qa.$qa_key \
               --gh_api_user ${{ secrets.auto_commit_user }} \
-              --gh_api_pwd ${{ secrets.auto_commit_pwd }}
+              --gh_api_pwd ${{ secrets.auto_commit_pwd }} $override_option
 
             # install test dependencies
             target_dir=$(cat ${{ env.CI_INTEGRATION_EXECUTION_FOLDER }}/target_dir.txt)

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -32,6 +32,7 @@ on:
         required: false
         type: string
         default: ""
+        description: Version of the simulator tests to run. If not provided, the version will be taken from the product manifest.
 
     secrets:
       auto_commit_user:


### PR DESCRIPTION
- Add option to override tests version

Blocked by: https://github.com/MOV-AI/integration-pipeline-ci-scripts/pull/150