### PR TITLE
DP-1865 - bump provision infra version to 2.0.0-16

### DIFF
--- a/.github/workflows/deploy-project.yml
+++ b/.github/workflows/deploy-project.yml
@@ -52,7 +52,7 @@ env:
   USERSPACE_FOLDER_PATH: userspace
   REMOTE_WORKSPACE_PATH: deploy_workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-15"
+  PROVISION_INFRA_VERSION: "2.0.0-16"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -111,7 +111,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-15"
+  PROVISION_INFRA_VERSION: "2.0.0-16"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -112,7 +112,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-15"
+  PROVISION_INFRA_VERSION: "2.0.0-16"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -72,7 +72,7 @@ env:
   JIRA_PASSWORD: ${{ secrets.jira_password}}
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-15"
+  PROVISION_INFRA_VERSION: "2.0.0-16"
   PROVISION_INFRA_DIR: "provision_scripts"
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"


### PR DESCRIPTION
This pull request updates the `PROVISION_INFRA_VERSION` environment variable across multiple GitHub workflow files to use version `2.0.0-16` instead of `2.0.0-15`. This ensures consistency in the infrastructure version used across different workflows.

Updates to environment variables in GitHub workflows:

* [`.github/workflows/deploy-project.yml`](diffhunk://#diff-e7d69104ea0e1dddab47d9e80c58b09cf8c4d408bfc51476970c8de52a8f3c06L55-R55): Changed `PROVISION_INFRA_VERSION` from `"2.0.0-15"` to `"2.0.0-16"`.
* [`.github/workflows/integration-build-product-composite.yml`](diffhunk://#diff-8f65998644f0cdf49f0a3e1c4ddc6ee6da6e791f8a51aa1224f928fd04933234L114-R114): Changed `PROVISION_INFRA_VERSION` from `"2.0.0-15"` to `"2.0.0-16"`.
* [`.github/workflows/integration-build-product.yml`](diffhunk://#diff-bfbc34c7422e454a0711853cff89419314a75ba02364b4ceb1d4ba7f278b8e2eL115-R115): Changed `PROVISION_INFRA_VERSION` from `"2.0.0-15"` to `"2.0.0-16"`.
* [`.github/workflows/integration-robotic-stack-tests.yml`](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL75-R75): Changed `PROVISION_INFRA_VERSION` from `"2.0.0-15"` to `"2.0.0-16"`.