### PR TITLE
DP-1887: add RPM packaging in movai-service

### DIFF
--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -381,7 +381,7 @@ jobs:
         run: |
           python3.11 -m venv test_venv
           source test_venv/bin/activate
-          python3.11 -m pip install -r build-requirements.txt requirements.txt
+          python3.11 -m pip install -r build-requirements.txt -r requirements.txt
           deactivate
 
       - name: Download pack artifacts

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -293,7 +293,8 @@ jobs:
         distro: ${{ fromJSON(inputs.distributions) }}
     needs: [Raise, Pack]
     if: ${{ inputs.release == 'false' && inputs.install_test == 'true' }}
-    runs-on: ${{ matrix.distro == 'focal' && 'ubuntu-20.04' || matrix.distro == 'jammy' && 'ubuntu-22.04' || matrix.distro == 'noble' && 'ubuntu-24.04' || matrix.distro == 'rocky8' && 'rocky-8' }}
+    # for rocky8 we use ubuntu-24.04 as we do not have a rocky8 runner
+    runs-on: ${{ matrix.distro == 'focal' && 'ubuntu-20.04' || matrix.distro == 'jammy' && 'ubuntu-22.04' || matrix.distro == 'noble' && 'ubuntu-24.04' || matrix.distro == 'rocky8' && 'ubuntu-24.04' }}
     timeout-minutes: 90
     steps:
       - name: Maximize build space
@@ -334,8 +335,8 @@ jobs:
         run: |
           sudo dnf install -y ./artifacts/movai-service*
 
-      - name: Run tests
-        if: ${{ inputs.skip_testing != 'true' }}
+      - name: Run tests on debian artifacts
+        if: ${{ inputs.skip_testing != 'true' && matrix.distro != 'rocky8' }}
         run: |
           source test_venv/bin/activate
           if [ -f tox.ini ]; then
@@ -346,6 +347,11 @@ jobs:
               python3 -m pytest tests/
           fi
           deactivate
+
+      - name: Run tests on rpm artifacts
+        if: ${{ inputs.skip_testing != 'true' && matrix.distro == 'rocky8' }}
+        run: |
+          make test_${{ matrix.distro }}
 
       - name: Store tests reports for SonarCloud
         uses: actions/upload-artifact@v4

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -293,7 +293,7 @@ jobs:
         distro: ${{ fromJSON(inputs.distributions) }}
     needs: [Raise, Pack]
     if: ${{ inputs.release == 'false' && inputs.install_test == 'true' }}
-    # for rocky8 we use ubuntu-24.04 as we do not have a rocky8 runner
+    # for rocky8 we use ubuntu-24.04 for simple install test
     runs-on: ${{ matrix.distro == 'focal' && 'ubuntu-20.04' || matrix.distro == 'jammy' && 'ubuntu-22.04' || matrix.distro == 'noble' && 'ubuntu-24.04' || matrix.distro == 'rocky8' && 'ubuntu-24.04' }}
     timeout-minutes: 90
     steps:
@@ -334,13 +334,7 @@ jobs:
         if: ${{ inputs.skip_testing != 'true' && matrix.distro != 'rocky8' }}
         run: |
           source test_venv/bin/activate
-          if [ -f tox.ini ]; then
-              # run tests and generates coverage.xml
-              tox
-          else
-              # run tests
-              python3 -m pytest tests/
-          fi
+          tox
           deactivate
 
       - name: Run tests on rpm artifacts
@@ -371,6 +365,65 @@ jobs:
           name: package_test_journal_${{ matrix.distro }}
           path: ./logs/*
           retention-days: 5
+
+  Package-Test-Rpm:
+    if: ${{ inputs.release == 'false' && inputs.install_test == 'true' && inputs.skip_testing != 'true' }}
+    needs: [Raise, Pack]
+    runs-on: oracle
+    timeout-minutes: 90
+    env:
+      RPM_DISTRO: rocky8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install test requirements
+        run: |
+          python3.11 -m venv test_venv
+          source test_venv/bin/activate
+          python3.11 -m pip install -r build-requirements.txt
+          deactivate
+
+      - name: Download pack artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pack_artifacts_${{ env.RPM_DISTRO }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Run tests on rpm artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/${{ env.RPM_DISTRO }}
+          mv artifacts/movai-service*.rpm artifacts/${{ env.RPM_DISTRO }}
+          source test_venv/bin/activate
+          tox
+          deactivate
+
+      - name: Store logs of journalctl
+        shell: bash
+        if: always()
+        run: |
+          mkdir -p logs
+          journalctl -u movai-service > ./logs/movai-service-journal-${{ env.RPM_DISTRO }}.log || true
+
+      - name: Stash logs of journalctl
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: package_rpm_test_journal_${{ env.RPM_DISTRO }}
+          path: ./logs/*
+          retention-days: 5
+
+      - name: Clean up
+        if: always()
+        shell: bash
+        run: |
+          sudo rm -rf artifacts
+          sudo rm -rf logs
+          sudo rm -rf test_venv
+          dnf remove movai-service* -y || true
+
 
   SonarCloud:
     if: ${{ inputs.release == 'false' }}
@@ -463,8 +516,8 @@ jobs:
       run: |
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
-  PublishDebToDev:
-    needs: [Raise, Pack, Package-Test, SonarCloud]
+  PublishPackagesToDev:
+    needs: [Raise, Pack, Package-Test, SonarCloud, Package-Test-Rpm]
     if: ${{ inputs.release == 'false' }}
     strategy:
       matrix:
@@ -484,6 +537,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish to Nexus ppa-dev
+        if: ${{ matrix.distro != 'rocky8' }}
         shell: bash
         run: |
             NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
@@ -514,10 +568,11 @@ jobs:
             done
 
       - name: Publish to Nexus yum-dev
+        if: ${{ matrix.distro == 'rocky8' }}
         shell: bash
         run: |
             NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
-            NEXUS_REPO="yum-dev-${{ matrix.distro }}"
+            NEXUS_REPO="yum-dev"
             for file in artifacts/*.rpm
             do
               RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
@@ -544,7 +599,7 @@ jobs:
             done
 
   PublishPyPiToExperimental:
-    needs: [Raise, Pack, Package-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud, Package-Test-Rpm]
     if: ${{ inputs.release == 'false' }}
     runs-on: ubuntu-22.04
     container:
@@ -568,7 +623,7 @@ jobs:
           packages-dir: dist/
 
   PublishPyPiToIntegration:
-    needs: [Raise, Pack, Package-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud, Package-Test-Rpm]
     if: ${{ inputs.deploy == 'true' }}
     runs-on: ubuntu-22.04
     container:
@@ -591,8 +646,8 @@ jobs:
           repository-url: https://artifacts.cloud.mov.ai/repository/pypi-integration/
           packages-dir: dist/
 
-  PublishDebToStaging:
-    needs: [Raise, Pack, Package-Test, SonarCloud]
+  PublishPackagesToStaging:
+    needs: [Raise, Pack, Package-Test, SonarCloud, Package-Test-Rpm]
     if: ${{ inputs.deploy == 'true' }}
     strategy:
       matrix:
@@ -612,6 +667,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish to Nexus ppa-testing
+        if: ${{ matrix.distro != 'rocky8' }}
         shell: bash
         run: |
             NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
@@ -643,10 +699,11 @@ jobs:
             done
 
       - name: Publish to Nexus yum-integration
+        if: ${{ matrix.distro == 'rocky8' }}
         shell: bash
         run: |
             NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
-            NEXUS_REPO="yum-integration-${{ matrix.distro }}"
+            NEXUS_REPO="yum-integration"
 
             for file in artifacts/*.rpm
             do
@@ -674,7 +731,7 @@ jobs:
             done
 
   Github-Release:
-    needs: [Raise, Pack, Package-Test, SonarCloud, PublishPyPiToIntegration, PublishDebToStaging]
+    needs: [Raise, Pack, Package-Test, Package-Test-Rpm, SonarCloud, PublishPyPiToIntegration, PublishPackagesToStaging]
     runs-on: ubuntu-22.04
     if: ${{ inputs.deploy == 'true' }}
     container:

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -572,32 +572,43 @@ jobs:
         if: ${{ matrix.distro == 'rocky8' }}
         shell: bash
         run: |
-            NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
-            NEXUS_REPO="yum-dev"
-            for file in artifacts/*.rpm
-            do
-              RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
-              -H "Content-Type: multipart/form-data" \
-              --data-binary "@$file" \
+          NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
+          NEXUS_REPO="yum-dev"
+
+          cd artifacts
+          for file in $(find -name "*.rpm" -not -name "*src*" -printf '%f\n')
+          do
+            echo "Uploading $file"
+            RETURN_CODE=$(curl -X 'POST' -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+              "https://$NEXUS_ENDPOINT/service/rest/v1/components?repository=$NEXUS_REPO" \
+              -H 'accept: application/json' \
+              -H 'Content-Type: multipart/form-data' \
               -w '%{http_code}' \
-              "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+              -F 'yum.directory=system' \
+              -F "yum.asset=@$file;type=application/x-rpm" \
+              -F "yum.asset.filename=$file"
+            )
 
-              #retry
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Retrying"
+            #retry
+            if [[ ! "$RETURN_CODE" =~ ^(200|201|202|204)$ ]]; then
+              echo "Failed upload $file with $RETURN_CODE. Retrying"
 
-                RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
-                  -H "Content-Type: multipart/form-data" \
-                  --data-binary "@$file" \
-                  -w '%{http_code}' \
-                  "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
-              fi
+              RETURN_CODE=$(curl -X 'POST' -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+                "https://$NEXUS_ENDPOINT/service/rest/v1/components?repository=$NEXUS_REPO" \
+                -H 'accept: application/json' \
+                -H 'Content-Type: multipart/form-data' \
+                -w '%{http_code}' \
+                -F 'yum.directory=system' \
+                -F "yum.asset=@$file;type=application/x-rpm" \
+                -F "yum.asset.filename=$file"
+              )
+            fi
 
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Exiting"
-                exit 1
-              fi
-            done
+            if [[ ! "$RETURN_CODE" =~ ^(200|201|202|204)$ ]]; then
+              echo "Failed upload $file with $RETURN_CODE. Exiting"
+              exit 1
+            fi
+          done
 
   PublishPyPiToExperimental:
     needs: [Raise, Pack, Package-Test, SonarCloud, Package-Test-Rpm]
@@ -706,27 +717,37 @@ jobs:
             NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
             NEXUS_REPO="yum-integration"
 
-            for file in artifacts/*.rpm
+            cd artifacts
+            for file in $(find -name "*.rpm" -not -name "*src*" -printf '%f\n')
             do
-              RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
-              -H "Content-Type: multipart/form-data" \
-              --data-binary "@$file" \
-              -w '%{http_code}' \
-              "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+              echo "Uploading $file"
+              RETURN_CODE=$(curl -X 'POST' -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+                "https://$NEXUS_ENDPOINT/service/rest/v1/components?repository=$NEXUS_REPO" \
+                -H 'accept: application/json' \
+                -H 'Content-Type: multipart/form-data' \
+                -w '%{http_code}' \
+                -F 'yum.directory=system' \
+                -F "yum.asset=@$file;type=application/x-rpm" \
+                -F "yum.asset.filename=$file"
+              )
 
               #retry
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Retrying"
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202|204)$ ]]; then
+                echo "Failed upload $file with $RETURN_CODE. Retrying"
 
-                RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
-                  -H "Content-Type: multipart/form-data" \
-                  --data-binary "@$file" \
+                RETURN_CODE=$(curl -X 'POST' -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+                  "https://$NEXUS_ENDPOINT/service/rest/v1/components?repository=$NEXUS_REPO" \
+                  -H 'accept: application/json' \
+                  -H 'Content-Type: multipart/form-data' \
                   -w '%{http_code}' \
-                  "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+                  -F 'yum.directory=system' \
+                  -F "yum.asset=@$file;type=application/x-rpm" \
+                  -F "yum.asset.filename=$file"
+                )
               fi
 
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Exiting"
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202|204)$ ]]; then
+                echo "Failed upload $file with $RETURN_CODE. Exiting"
                 exit 1
               fi
             done

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -346,6 +346,8 @@ jobs:
       - name: Run tests on rpm artifacts
         if: ${{ inputs.skip_testing != 'true' && matrix.distro == 'rocky8' }}
         run: |
+          mkdir -p artifacts/${{ matrix.distro }}
+          mv artifacts/movai-service*.rpm artifacts/${{ matrix.distro }}
           make test_${{ matrix.distro }}
 
       - name: Store tests reports for SonarCloud

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -396,6 +396,7 @@ jobs:
         run: |
           mkdir -p artifacts/${{ env.RPM_DISTRO }}
           mv artifacts/movai-service*.rpm artifacts/${{ env.RPM_DISTRO }}
+          sudo rpm -i artifacts/${{ env.RPM_DISTRO }}/movai-service*.rpm --replacefiles || true
           source test_venv/bin/activate
           pytest tests/ --cov=movai_service --cov=movai_cli --cov=extra-plugins --cov=scripts --cov-report=term --cov-report=xml -o log_cli=true -x
           deactivate

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -22,7 +22,7 @@ on:
       distributions:
         required: false
         type: string
-        default: '["jammy", "noble"]'
+        default: '["jammy", "noble", "rocky8"]'
       install_test:
         required: false
         type: string
@@ -246,7 +246,7 @@ jobs:
           commit_hash=$(git log --format="%H" -n 1)
           echo "commit_id=$commit_hash" | tee -a $GITHUB_OUTPUT
 
-  Debian-Pack:
+  Pack:
     if: ${{ inputs.release == 'false' }}
     strategy:
       matrix:
@@ -269,7 +269,7 @@ jobs:
         password: ${{ secrets.registry_password }}
         registry: registry.cloud.mov.ai
 
-    - name: Raise & Deb Pack in containers
+    - name: Raise & Pack in containers
       env:
         PACKAGE_VERSION: ${{ needs.Raise.outputs.package_version }}
       run: |
@@ -281,17 +281,19 @@ jobs:
     - name: Archive binary
       uses: actions/upload-artifact@v4
       with:
-        name: deb_artifacts_${{ matrix.distro }}
-        path: artifacts/${{ matrix.distro }}/*.deb
+        name: pack_artifacts_${{ matrix.distro }}
+        path: |
+          artifacts/${{ matrix.distro }}/*.deb
+          artifacts/${{ matrix.distro }}/*.rpm
         retention-days: 5
 
-  Debian-Test:
+  Package-Test:
     strategy:
       matrix:
         distro: ${{ fromJSON(inputs.distributions) }}
-    needs: [Raise, Debian-Pack]
+    needs: [Raise, Pack]
     if: ${{ inputs.release == 'false' && inputs.install_test == 'true' }}
-    runs-on: ubuntu-${{ matrix.distro == 'focal' && '20.04' || matrix.distro == 'jammy' && '22.04' || matrix.distro == 'noble' && '24.04' }}
+    runs-on: ${{ matrix.distro == 'focal' && 'ubuntu-20.04' || matrix.distro == 'jammy' && 'ubuntu-22.04' || matrix.distro == 'noble' && 'ubuntu-24.04' || matrix.distro == 'rocky8' && 'rocky-8' }}
     timeout-minutes: 90
     steps:
       - name: Maximize build space
@@ -314,17 +316,23 @@ jobs:
           python3 -m pip install -r build-requirements.txt
           deactivate
 
-      - name: Download deb artifacts
+      - name: Download pack artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: deb_artifacts_${{ matrix.distro }}
+          pattern: pack_artifacts_${{ matrix.distro }}
           path: artifacts
           merge-multiple: true
 
       - name: Install debian artifacts
+        if: ${{ matrix.distro != 'rocky8' }}
         run: |
           sudo apt update
           sudo apt install -y ./artifacts/movai-service*
+
+      - name: Install rpm artifacts
+        if: ${{ matrix.distro == 'rocky8' }}
+        run: |
+          sudo dnf install -y ./artifacts/movai-service*
 
       - name: Run tests
         if: ${{ inputs.skip_testing != 'true' }}
@@ -357,13 +365,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: debian_test_journal_${{ matrix.distro }}
+          name: package_test_journal_${{ matrix.distro }}
           path: ./logs/*
           retention-days: 5
 
   SonarCloud:
     if: ${{ inputs.release == 'false' }}
-    needs: [Debian-Test]
+    needs: [Package-Test]
     runs-on: ubuntu-22.04
     container:
       image: registry.cloud.mov.ai/qa/py-buildserver:v3.0.4
@@ -453,7 +461,7 @@ jobs:
         echo "Please check report here: https://sonarcloud.io/project/overview?id=${{ github.repository_owner }}_${{ github.event.repository.name }}"
 
   PublishDebToDev:
-    needs: [Raise, Debian-Pack, Debian-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud]
     if: ${{ inputs.release == 'false' }}
     strategy:
       matrix:
@@ -465,10 +473,10 @@ jobs:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
     steps:
-      - name: Download deb artifacts
+      - name: Download pack artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: deb_artifacts_${{ matrix.distro }}
+          pattern: pack_artifacts_${{ matrix.distro }}
           path: artifacts
           merge-multiple: true
 
@@ -502,8 +510,38 @@ jobs:
               fi
             done
 
+      - name: Publish to Nexus yum-dev
+        shell: bash
+        run: |
+            NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
+            NEXUS_REPO="yum-dev-${{ matrix.distro }}"
+            for file in artifacts/*.rpm
+            do
+              RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+              -H "Content-Type: multipart/form-data" \
+              --data-binary "@$file" \
+              -w '%{http_code}' \
+              "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+
+              #retry
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+                echo "Failed upload with $RETURN_CODE. Retrying"
+
+                RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+                  -H "Content-Type: multipart/form-data" \
+                  --data-binary "@$file" \
+                  -w '%{http_code}' \
+                  "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+              fi
+
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+                echo "Failed upload with $RETURN_CODE. Exiting"
+                exit 1
+              fi
+            done
+
   PublishPyPiToExperimental:
-    needs: [Raise, Debian-Pack, Debian-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud]
     if: ${{ inputs.release == 'false' }}
     runs-on: ubuntu-22.04
     container:
@@ -527,7 +565,7 @@ jobs:
           packages-dir: dist/
 
   PublishPyPiToIntegration:
-    needs: [Raise, Debian-Pack, Debian-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud]
     if: ${{ inputs.deploy == 'true' }}
     runs-on: ubuntu-22.04
     container:
@@ -551,7 +589,7 @@ jobs:
           packages-dir: dist/
 
   PublishDebToStaging:
-    needs: [Raise, Debian-Pack, Debian-Test, SonarCloud]
+    needs: [Raise, Pack, Package-Test, SonarCloud]
     if: ${{ inputs.deploy == 'true' }}
     strategy:
       matrix:
@@ -563,10 +601,10 @@ jobs:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
     steps:
-      - name: Download deb artifacts
+      - name: Download pack artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: deb_artifacts_${{ matrix.distro }}
+          pattern: pack_artifacts_${{ matrix.distro }}
           path: artifacts
           merge-multiple: true
 
@@ -601,8 +639,39 @@ jobs:
               fi
             done
 
+      - name: Publish to Nexus yum-integration
+        shell: bash
+        run: |
+            NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
+            NEXUS_REPO="yum-integration-${{ matrix.distro }}"
+
+            for file in artifacts/*.rpm
+            do
+              RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+              -H "Content-Type: multipart/form-data" \
+              --data-binary "@$file" \
+              -w '%{http_code}' \
+              "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+
+              #retry
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+                echo "Failed upload with $RETURN_CODE. Retrying"
+
+                RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+                  -H "Content-Type: multipart/form-data" \
+                  --data-binary "@$file" \
+                  -w '%{http_code}' \
+                  "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+              fi
+
+              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+                echo "Failed upload with $RETURN_CODE. Exiting"
+                exit 1
+              fi
+            done
+
   Github-Release:
-    needs: [Raise, Debian-Pack, Debian-Test, SonarCloud, PublishPyPiToIntegration, PublishDebToStaging]
+    needs: [Raise, Pack, Package-Test, SonarCloud, PublishPyPiToIntegration, PublishDebToStaging]
     runs-on: ubuntu-22.04
     if: ${{ inputs.deploy == 'true' }}
     container:
@@ -652,7 +721,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
-  Github-Release-Debian-Upload:
+  Github-Release-Packages-Upload:
     needs: [Raise, Github-Release]
     runs-on: ubuntu-22.04
     if: ${{ inputs.deploy == 'true' }}
@@ -668,24 +737,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download deb artifacts
+      - name: Download pack artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: deb_artifacts_${{ matrix.distro }}
+          pattern: pack_artifacts_${{ matrix.distro }}
           path: artifacts
           merge-multiple: true
 
-      - name: Update Github Release
+      - name: Update Github Release with debian artifacts
         shell: bash
         run: |
           git config --global user.name ${{ secrets.auto_commit_user }}
           git config --global user.email ${{ secrets.auto_commit_mail }}
           git config --global --add safe.directory $(pwd)
-          for asset in artifacts/*; do
+          for asset in artifacts/*.deb; do
             # do nothing if folder is empty
             if [[ $asset != "artifacts/*" ]]; then
               # Add sufix of distro to asset name
               asset_renamed=$(basename $asset .deb)_${{ matrix.distro }}.deb
+              cp $asset $asset_renamed
+              gh release upload ${{ needs.Raise.outputs.package_version }} $asset_renamed
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+      - name: Update Github Release with rpm artifacts
+        shell: bash
+        run: |
+          git config --global user.name ${{ secrets.auto_commit_user }}
+          git config --global user.email ${{ secrets.auto_commit_mail }}
+          git config --global --add safe.directory $(pwd)
+          for asset in artifacts/*.rpm; do
+            # do nothing if folder is empty
+            if [[ $asset != "artifacts/*" ]]; then
+              # Add sufix of distro to asset name
+              asset_renamed=$(basename $asset .rpm)_${{ matrix.distro }}.rpm
               cp $asset $asset_renamed
               gh release upload ${{ needs.Raise.outputs.package_version }} $asset_renamed
             fi
@@ -754,7 +841,7 @@ jobs:
       max-parallel: 1
 
     steps:
-    - name: Download deb artifacts
+    - name: Download pack artifacts
       uses: actions/download-artifact@v4
       with:
         name: released_deb_artifacts
@@ -763,33 +850,33 @@ jobs:
     - name: Publish to Nexus
       shell: bash
       run: |
-            NEXUS_REPO="${{ matrix.publish_repo }}-${{ matrix.distro }}"
-            NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
+        NEXUS_REPO="${{ matrix.publish_repo }}-${{ matrix.distro }}"
+        NEXUS_ENDPOINT="artifacts.cloud.mov.ai"
 
-            ls -la artifacts
+        ls -la artifacts
 
-            for file in artifacts/*_${{ matrix.distro }}.deb
-            do
-              RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+        for file in artifacts/*_${{ matrix.distro }}.deb
+        do
+          RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
+          -H "Content-Type: multipart/form-data" \
+          --data-binary "@$file" \
+          -w '%{http_code}' \
+          "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+
+          #retry
+          if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+            echo "Failed upload with $RETURN_CODE. Retrying"
+
+            RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
               -H "Content-Type: multipart/form-data" \
               --data-binary "@$file" \
               -w '%{http_code}' \
               "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
+          fi
 
-              #retry
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Retrying"
+          if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
+            echo "Failed upload with $RETURN_CODE. Exiting"
+            exit 1
+          fi
 
-                RETURN_CODE=$(curl -u "${{ secrets.nexus_publisher_user }}:${{ secrets.nexus_publisher_password }}" \
-                  -H "Content-Type: multipart/form-data" \
-                  --data-binary "@$file" \
-                  -w '%{http_code}' \
-                  "https://$NEXUS_ENDPOINT/repository/$NEXUS_REPO/")
-              fi
-
-              if [[ ! "$RETURN_CODE" =~ ^(200|201|202)$ ]]; then
-                echo "Failed upload with $RETURN_CODE. Exiting"
-                exit 1
-              fi
-
-            done
+        done

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -330,11 +330,6 @@ jobs:
           sudo apt update
           sudo apt install -y ./artifacts/movai-service*
 
-      - name: Install rpm artifacts
-        if: ${{ matrix.distro == 'rocky8' }}
-        run: |
-          sudo dnf install -y ./artifacts/movai-service*
-
       - name: Run tests on debian artifacts
         if: ${{ inputs.skip_testing != 'true' && matrix.distro != 'rocky8' }}
         run: |

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -381,7 +381,7 @@ jobs:
         run: |
           python3.11 -m venv test_venv
           source test_venv/bin/activate
-          python3.11 -m pip install -r build-requirements.txt
+          python3.11 -m pip install -r build-requirements.txt requirements.txt
           deactivate
 
       - name: Download pack artifacts
@@ -397,7 +397,7 @@ jobs:
           mkdir -p artifacts/${{ env.RPM_DISTRO }}
           mv artifacts/movai-service*.rpm artifacts/${{ env.RPM_DISTRO }}
           source test_venv/bin/activate
-          tox
+          pytest tests/ --cov=movai_service --cov=movai_cli --cov=extra-plugins --cov=scripts --cov-report=term --cov-report=xml -o log_cli=true -x
           deactivate
 
       - name: Store logs of journalctl
@@ -422,7 +422,7 @@ jobs:
           sudo rm -rf artifacts
           sudo rm -rf logs
           sudo rm -rf test_venv
-          dnf remove movai-service* -y || true
+          sudo dnf remove movai-service* -y || true
 
 
   SonarCloud:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # v2.3
 
 - py-workflow : added support for pre-commit, build, and test on different versions of python (excluding Python 3.8, and other versions)
-- service-py-deb-workflow : dedicated workflow for building, packaging and testing movai-service
+- service-py-deb-workflow : dedicated workflow for building, packaging and testing movai-service for Debian and RPM Linux distributions


### PR DESCRIPTION
This pull request updates the `.github/workflows/service-py-deb-workflow.yml` file to expand support for RPM-based distributions (e.g., Rocky Linux) alongside existing Debian-based distributions. It introduces new job names, modifies artifact naming conventions, adds RPM-specific testing and publishing steps, and updates the changelog to reflect these changes.

### Workflow Updates for RPM Support:

#### General Changes:
* Added `rocky8` to the list of supported distributions in the `distributions` input. (`[.github/workflows/service-py-deb-workflow.ymlL25-R25](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L25-R25)`)
* Renamed job and artifact names from "Debian" to "Package" or "Pack" to reflect support for both Debian and RPM packages. (`[[1]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L249-R249)`, `[[2]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L284-R297)`, `[[3]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L360-R431)`)

#### Testing Enhancements:
* Introduced RPM-specific testing steps, including installation and execution of tests for `rocky8`. (`[.github/workflows/service-py-deb-workflow.ymlL317-R346](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L317-R346)`)
* Added a new job, `Package-Test-Rpm`, for RPM-specific testing on Oracle Linux. (`[.github/workflows/service-py-deb-workflow.ymlL360-R431](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L360-R431)`)

#### Publishing Updates:
* Added RPM publishing steps to Nexus repositories for `yum-dev` and `yum-integration` alongside existing Debian publishing workflows. (`[[1]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83R571-R603)`, `[[2]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83R702-R735)`)
* Updated GitHub release jobs to handle both `.deb` and `.rpm` artifacts. (`[[1]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L655-R785)`, `[[2]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83R826-R843)`)

### Documentation:
* Updated `CHANGELOG.md` to reflect the expanded support for RPM distributions in the `service-py-deb-workflow`. (`[CHANGELOG.mdL4-R4](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL4-R4)`)