### PR TITLE
Fix coverage in Python workflows

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -440,7 +440,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: coverage
-        path: coverage.xml
+        path: coverage
 
     - name: Create SonarCloud project and disable autoscan
       uses: MOV-AI/action-sonarcloud-proj-config@v1
@@ -467,7 +467,7 @@ jobs:
           -Dsonar.python.version=3
           -Dsonar.python.flake8.reportPaths=flake8-report.txt
           -Dsonar.python.pylint.reportPaths=pylint-report.txt
-          -Dsonar.python.coverage.reportPaths=coverage.xml
+          -Dsonar.python.coverage.reportPaths=coverage/coverage.xml
 
     - name: Link to SonarCloud dashboard
       shell: bash


### PR DESCRIPTION
- Fix coverage in Python workflows
  - Coverage path was not correct, giving the error `Cannot read coverage report '/home/runner/work/data-access-layer/data-access-layer/coverage.xml', the following exception occurred: 'Error parsing the report '/home/runner/work/data-access-layer/data-access-layer/coverage.xml''`
  - Tested in https://github.com/MOV-AI/data-access-layer/actions/runs/16623980639