### PR TITLE
service-py-deb-workflow: fix sonar coverage and minor issues seen on release to main

### DIFF
--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -96,7 +96,6 @@ jobs:
       if: ${{ inputs.run_black == 'true' }}
       run: |
         python3 -m black \
-          --line-length 120 \
           --diff \
           --check \
           .
@@ -107,7 +106,6 @@ jobs:
           --isolated \
           --exclude dist,.*\.egg-info,.git,__pycache__,.tox,venv \
           --max-complexity 16 \
-          --max-line-length 120 \
           --exit-zero \
           --output-file flake8-report.txt
 
@@ -117,7 +115,6 @@ jobs:
         python3 -m pylint \
           --rcfile dummy-pylint-config \
           --ignore-patterns dist,.*\.egg-info,.git,__pycache__,.tox,venv \
-          --max-line-length 120 \
           --exit-zero \
           --recursive y \
           --output pylint-report.txt \
@@ -480,15 +477,16 @@ jobs:
           -Dsonar.scm.provider=git
           -Dsonar.qualitygate.wait=true
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.coverage.exclusions=tests/**
-          -Dsonar.cpd.exclusions=tests/**
+          -Dsonar.coverage.exclusions=tests/**,docs/**
+          -Dsonar.cpd.exclusions=tests/**,docs/**
           -Dsonar.python.version=3
           -Dsonar.python.line_length=120
           -Dsonar.python.cyclomatic.complexity=16
           -Dsonar.python.flake8.reportPaths=flake8-report.txt
           -Dsonar.python.pylint.reportPaths=pylint-report.txt
+          -Dsonar.python.coverage.reportPaths=coverage.xml
 
-    - name: SonarCloud Scan and Quality Gate check (no coverage)
+    - name: SonarCloud Scan no Quality Gate check
       uses: SonarSource/sonarcloud-github-action@v2.0.2
       if: ${{ inputs.skip_testing == 'true' }}
       env:
@@ -501,10 +499,10 @@ jobs:
           -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
           -Dsonar.sources=.
           -Dsonar.scm.provider=git
-          -Dsonar.qualitygate.wait=true
+          -Dsonar.qualitygate.wait=false
           -Dsonar.qualitygate.timeout=300
-          -Dsonar.coverage.exclusions=tests/**
-          -Dsonar.cpd.exclusions=tests/**
+          -Dsonar.coverage.exclusions=tests/**,docs/**
+          -Dsonar.cpd.exclusions=tests/**,docs/**
           -Dsonar.python.version=3
           -Dsonar.python.line_length=120
           -Dsonar.python.cyclomatic.complexity=16

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -827,6 +827,7 @@ jobs:
           merge-multiple: true
 
       - name: Update Github Release with debian artifacts
+        if: ${{ matrix.distro != 'rocky8' }}
         shell: bash
         run: |
           git config --global user.name ${{ secrets.auto_commit_user }}
@@ -845,6 +846,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Update Github Release with rpm artifacts
+        if: ${{ matrix.distro == 'rocky8' }}
         shell: bash
         run: |
           git config --global user.name ${{ secrets.auto_commit_user }}


### PR DESCRIPTION
This pull request makes several updates to the `.github/workflows/service-py-deb-workflow.yml` file, focusing on improving code quality checks, refining SonarCloud configurations, and adding conditional logic for artifact updates. The most significant changes include removing the `--max-line-length` parameter from various tools, updating SonarCloud exclusions and settings, and introducing conditional checks for updating GitHub releases based on the distribution.

### Code Quality Check Updates:
* Removed the `--max-line-length` parameter from `black`, `flake8`, and `pylint` commands to rely on default or other configurations for line length enforcement. [[1]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L99) [[2]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L110) [[3]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L120)

### SonarCloud Configuration Updates:
* Expanded the `sonar.coverage.exclusions` and `sonar.cpd.exclusions` to include `docs/**` in addition to `tests/**`. [[1]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L483-R489) [[2]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83L504-R505)
* Added `sonar.python.coverage.reportPaths=coverage.xml` to include coverage reports in SonarCloud analysis.
* Set `sonar.qualitygate.wait` to `false` for the "SonarCloud Scan no Quality Gate check" step to disable waiting for the quality gate.

### Conditional Logic for Artifact Updates:
* Added a condition to skip updating GitHub releases with Debian artifacts for the `rocky8` distribution.
* Added a condition to update GitHub releases with RPM artifacts only for the `rocky8` distribution.