### PR TITLE
Add AWS CLI check to workflows and remove installation steps

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1369,6 +1369,14 @@ jobs:
           python3 -m pip install --upgrade pyOpenSSL cryptography
           python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
+      - name: Check AWS Cli
+        shell: bash
+        run: |
+          if ! command -v aws &> /dev/null; then
+            echo "AWS CLI could not be found, please install it."
+            exit 1
+          fi
+
       - name: unstash raised_meta
         if: ${{ inputs.with_simulation_tests }}
         uses: actions/download-artifact@v4
@@ -1935,9 +1943,6 @@ jobs:
         if: ${{ always() &&  inputs.with_simulation_tests }}
         shell: bash
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
           zip -r qa_artifacts.zip qa_artifacts/
 
       - name: Stash QA artifacts (Minio)

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -111,6 +111,14 @@ jobs:
         run: |
           echo "ip=$(hostname -I | awk '{print $1}')" | tee $GITHUB_OUTPUT
 
+      - name: Check AWS Cli
+        shell: bash
+        run: |
+          if ! command -v aws &> /dev/null; then
+            echo "AWS CLI could not be found, please install it."
+            exit 1
+          fi
+
       - name: Login to Private Registry
         uses: docker/login-action@v2
         with:
@@ -664,9 +672,6 @@ jobs:
         shell: bash
         id: minio_publish
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
           URI_OBJ_PATH=ci-artifacts/${{ github.repository }}/$(date '+%Y_%m_%d')/${{ github.run_id}}/${{ github.job }}/attempts/${{ github.run_attempt }}
 
           MAX_RETRIES=5


### PR DESCRIPTION
Remove unecessary aws cli installation

Impact was 50+ GB of aws-cli files in the marvin queuer in `/usr/local/aws-cli/v2`