### PR TITLE
DP-1940: cleanup step for ci-venv

### DIFF
--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -231,6 +231,15 @@ jobs:
           path: platform_configs/*
           retention-days: 5
 
+      - name: Cleanup CI workspace
+        if: always()
+        shell: bash
+        run: |
+          rm -rf ci-venv
+          rm -rf ci_artifacts
+          rm -rf simulator_artifacts
+          rm -rf platform_configs
+
   Build-Spawner:
     needs: [Validate-boostrap-configs]
     strategy:
@@ -828,6 +837,7 @@ jobs:
           echo "private ip: $(hostname -I | awk '{print $1}')"
 
       - name: Setup CI Scripts in ci-venv
+        if: ${{ needs.Build-Simulator.outputs.skip_simulator == 'false' && inputs.with_simulation }}
         shell: bash
         run: |
           python3 -m venv ci-venv --clear


### PR DESCRIPTION
This pull request introduces improvements to the CI workflow defined in `.github/workflows/integration-build-product-composite.yml`. The main changes focus on better resource cleanup after CI runs and ensuring that environment setup steps are only executed when necessary.

**CI workflow improvements:**

* Added a new step to clean up the CI workspace by removing temporary directories (`ci-venv`, `ci_artifacts`, `simulator_artifacts`, and `platform_configs`) at the end of the workflow, regardless of the job outcome.

**Conditional execution enhancements:**

* Updated the "Setup CI Scripts in ci-venv" step to run only if the simulator build is not skipped and simulation is requested, preventing unnecessary environment setup.