### PR TITLE
DP-1886: Update helm-workflow to include nexus encryption key

### DIFF
--- a/.github/workflows/helm-workflow.yml
+++ b/.github/workflows/helm-workflow.yml
@@ -72,7 +72,7 @@ jobs:
           echo '${{ secrets.chart_secrets }}'>secrets.json
           python3 -m pip install jinja-cli
           find . -type f -name '*.yaml' -exec jinja -d secrets.json {} -o {} \;
-          find . -type f -name '*.json' -exec jinja -d secrets.json {} -o {} \;
+          find . -type f -name '*.json' ! -name 'secrets.json' -exec jinja -d secrets.json {} -o {} \;
 
       - name: Deploy Helm Chart
         id: deploy

--- a/.github/workflows/helm-workflow.yml
+++ b/.github/workflows/helm-workflow.yml
@@ -39,8 +39,6 @@ on:
         required: true
       chart_secrets:
         required: false
-      nexus_encryption_key_json:
-        required: false
 
 
 env:
@@ -71,16 +69,10 @@ jobs:
       - name: Replace Secrets
         shell: bash
         run: |
-          echo '${{ secrets.nexus_encryption_key_json }}'>nexus_encryption_key.json
-          python3 -m pip install jinja-cli
-          find . -type f -name '*.yaml' -exec jinja -d nexus_encryption_key.json {} -o {} \;
-
-      - name: Replace Secrets
-        shell: bash
-        run: |
           echo '${{ secrets.chart_secrets }}'>secrets.json
           python3 -m pip install jinja-cli
           find . -type f -name '*.yaml' -exec jinja -d secrets.json {} -o {} \;
+          find . -type f -name '*.json' -exec jinja -d secrets.json {} -o {} \;
 
       - name: Deploy Helm Chart
         id: deploy

--- a/.github/workflows/helm-workflow.yml
+++ b/.github/workflows/helm-workflow.yml
@@ -39,6 +39,8 @@ on:
         required: true
       chart_secrets:
         required: false
+      nexus_encryption_key_json:
+        required: false
 
 
 env:
@@ -65,6 +67,13 @@ jobs:
         run: |
           aws eks --region ${{ env.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ inputs.aws_cluster_name }}
           kubectl get svc,po
+
+      - name: Replace Secrets
+        shell: bash
+        run: |
+          echo '${{ secrets.nexus_encryption_key_json }}'>nexus_encryption_key.json
+          python3 -m pip install jinja-cli
+          find . -type f -name '*.yaml' -exec jinja -d nexus_encryption_key.json {} -o {} \;
 
       - name: Replace Secrets
         shell: bash


### PR DESCRIPTION
This pull request updates the Helm workflow to support injecting and templating secrets using a new `nexus_encryption_key_json` input. The workflow now processes YAML files with Jinja templates, allowing dynamic secret replacement during deployments.

**Secret injection and templating improvements:**

* Added a new optional workflow input `nexus_encryption_key_json` to support passing encrypted secrets to the workflow. (.github/workflows/helm-workflow.yml)
* Introduced a new workflow step that writes the `nexus_encryption_key_json` secret to a file, installs `jinja-cli`, and renders all `.yaml` files using Jinja templating with the provided secrets. (.github/workflows/helm-workflow.yml)