### PR TITLE
QAP-2693 and DP-1951: Update SonarCloud version in npm_worflow

### DIFF
--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -184,6 +184,7 @@ jobs:
           -Dsonar.coverage.exclusions=**/*.test.js,**/*.test.jsx
           -Dsonar.cpd.exclusions=**/*.test.js,**/*.test.jsx
           -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+          -Dsonar.nodejs.executable=$(which node)
 
     - name: Link to SonarCloud dashboard
       shell: bash

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -172,22 +172,22 @@ jobs:
         sonar_token: ${{ secrets.sonar_token }}
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@v2.0.2
+      uses: SonarSource/sonarqube-scan-action@v6
       env:
         GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.sonar_token }}
       with:
         projectBaseDir: ./
         args: >
-          -Dsonar.organization=mov-ai
-          -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
-          -Dsonar.sources=.
-          -Dsonar.scm.provider=git
-          -Dsonar.qualitygate.wait=true
-          -Dsonar.qualitygate.timeout=300
-          -Dsonar.coverage.exclusions=**/*.test.js,**/*.test.jsx
-          -Dsonar.cpd.exclusions=**/*.test.js,**/*.test.jsx
-          -Dsonar.nodejs.executable=${{ steps.build_step.outputs.node_path }}
+          "-Dsonar.organization=mov-ai"
+          "-Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}"
+          "-Dsonar.sources=."
+          "-Dsonar.scm.provider=git"
+          "-Dsonar.qualitygate.wait=true"
+          "-Dsonar.qualitygate.timeout=300"
+          "-Dsonar.coverage.exclusions=**/*.test.js,**/*.test.jsx"
+          "-Dsonar.cpd.exclusions=**/*.test.js,**/*.test.jsx"
+          "-Dsonar.nodejs.executable=${{ steps.build_step.outputs.node_path }}"
 
     - name: Link to SonarCloud dashboard
       shell: bash

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -151,7 +151,11 @@ jobs:
         ${{ inputs.pm }} version prerelease --no-git-tag-version
 
     - name: Build
-      run: ${{ inputs.pm }} run build
+      id: build_step
+      run: |
+        node_path=$(which node)
+        echo "node_path=$node_path" >> $GITHUB_OUTPUT
+        ${{ inputs.pm }} run build
 
     - name: Check NPM log on failure
       if: ${{ failure() }}
@@ -183,8 +187,7 @@ jobs:
           -Dsonar.qualitygate.timeout=300
           -Dsonar.coverage.exclusions=**/*.test.js,**/*.test.jsx
           -Dsonar.cpd.exclusions=**/*.test.js,**/*.test.jsx
-          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
-          -Dsonar.nodejs.executable=$(which node)
+          -Dsonar.nodejs.executable=${{ steps.build_step.outputs.node_path }}
 
     - name: Link to SonarCloud dashboard
       shell: bash

--- a/.github/workflows/npm-workflow.yml
+++ b/.github/workflows/npm-workflow.yml
@@ -187,6 +187,7 @@ jobs:
           "-Dsonar.qualitygate.timeout=300"
           "-Dsonar.coverage.exclusions=**/*.test.js,**/*.test.jsx"
           "-Dsonar.cpd.exclusions=**/*.test.js,**/*.test.jsx"
+          "-Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info"
           "-Dsonar.nodejs.executable=${{ steps.build_step.outputs.node_path }}"
 
     - name: Link to SonarCloud dashboard


### PR DESCRIPTION
This pull request updates the CI workflow for npm builds and SonarCloud scanning. The main improvements are the addition of a build step that exposes the Node.js executable path for downstream use, and a switch to a newer SonarQube scan action that allows specifying the Node.js path for more reliable scans.

Workflow build step improvements:
* Added an explicit `build_step` that outputs the detected Node.js path to `$GITHUB_OUTPUT`, making it available for later workflow steps.

SonarCloud scan enhancements:
* Switched from `SonarSource/sonarcloud-github-action@v2.0.2` to the newer `SonarSource/sonarqube-scan-action@v6` for SonarCloud scanning.
* Updated SonarQube scan arguments to use quoted strings for each property, improving YAML compatibility.
* Added the `-Dsonar.nodejs.executable` argument, passing the Node.js path detected in the build step to SonarQube for more reliable JavaScript analysis.