### PR TITLE
Add node path output to build step in workflow

### DIFF
--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -186,7 +186,11 @@ jobs:
           }
 
     - name: Build
-      run: ${{ inputs.pm }} run build
+      id: build_step
+      run: |
+        node_path=$(which node)
+        echo "node_path=$node_path" >> $GITHUB_OUTPUT
+        ${{ inputs.pm }} run build
 
     - name: Check NPM log on failure
       if: ${{ failure() }}


### PR DESCRIPTION
This pull request makes a minor update to the frontend workflow by capturing the path to the Node.js executable during the build step. This can be useful for debugging or for use in subsequent workflow steps.

* Updated the "Build" job in `.github/workflows/frontend-workflow.yml` to save the path to the Node.js executable in the GitHub Actions output (`node_path`).<!-- Please describe your pull request here. -->

