### PR TITLE
v2.1 - bump devops-tf-proxmox-bpg to 2.0.0-17

### DIFF
--- a/.github/workflows/deploy-project.yml
+++ b/.github/workflows/deploy-project.yml
@@ -52,7 +52,7 @@ env:
   USERSPACE_FOLDER_PATH: userspace
   REMOTE_WORKSPACE_PATH: deploy_workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-16"
+  PROVISION_INFRA_VERSION: "2.0.0-17"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -1315,7 +1315,7 @@ jobs:
         shell: bash
         run: |
           provision_infra_dir=provision_scripts
-          provision_infra_version=1.0.0-3
+          provision_infra_version=2.0.0-17
           provision_infra_repo_name=devops-tf-proxmox-bpg
 
           rm -rf $provision_infra_dir

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -98,8 +98,10 @@ env:
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   # development slack channel
   #SLACK_CHANNEL: "C05K2KF1UP8"
-  PROVISIONING_ENV_VERSION: 0.1.0-17
+  PROVISIONING_ENV_VERSION: 0.2.0-2
   PROVISIONING_ENV_REPO: devops-tf-env-conf
+  PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
+  PROVISION_INFRA_VERSION: "2.0.0-17"
   ARTIFACTS_RETENTION_DAYS: 15
 
 jobs:
@@ -368,7 +370,7 @@ jobs:
             --movai-user ${{ steps.install.outputs.movai_user }} \
             --movai-pw ${{ steps.install.outputs.movai_pwd }} \
             --cucumberjson=./results.json \
-            --junit-xml=junit.xml 
+            --junit-xml=junit.xml
 
           curl -LO https://trunk.io/releases/trunk && chmod +x ./trunk
           ./trunk flakytests upload \
@@ -622,13 +624,13 @@ jobs:
           pip install buildkite-test-collector
           curl -LO https://trunk.io/releases/trunk && chmod +x ./trunk
           if [ "${{ steps.install_tests_setup.outputs.jira_report }}" == "True" ] ; then
-          
+
           python3 -m pytest tests/ \
               -ra \
               -k '${{ steps.install_tests_setup.outputs.test_set }}' \
               --installPath="." --jsonConfigFilePath="../basic-standalone-noetic.json.ci" \
               --jira_report \
-              --junit-xml=junit.xml 
+              --junit-xml=junit.xml
 
           else
           python3 -m pytest tests/ \
@@ -641,7 +643,7 @@ jobs:
               --token "60df2c8fa3c66877002b26c722ec2708e80d7fad" \
               --junit-paths "junit.xml" # replace this with the path to your junit files
           deactivate
-          
+
           user=$(cat results/credentials.txt | awk -F: '{print $1}')
           pwd=$(cat results/credentials.txt | awk -F: '{print $2}')
 
@@ -920,7 +922,7 @@ jobs:
             -m "not fleet" \
             --junit-xml=junit.xml
 
-            
+
           ./trunk flakytests upload \
               --org-url-slug "movai" \
               --token "60df2c8fa3c66877002b26c722ec2708e80d7fad" \
@@ -1315,8 +1317,8 @@ jobs:
         shell: bash
         run: |
           provision_infra_dir=provision_scripts
-          provision_infra_version=2.0.0-17
-          provision_infra_repo_name=devops-tf-proxmox-bpg
+          provision_infra_version=${{ env.PROVISION_INFRA_VERSION }}
+          provision_infra_repo_name=${{ env.PROVISION_INFRA_REPO }}
 
           rm -rf $provision_infra_dir
           . .ci-venv/bin/activate
@@ -1932,7 +1934,7 @@ jobs:
             -m 'simulator' \
             --tb=short \
             --junit-xml=junit.xml
-            
+
           ./trunk flakytests upload \
             --org-url-slug "movai" \
             --token "60df2c8fa3c66877002b26c722ec2708e80d7fad" \

--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -111,7 +111,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-16"
+  PROVISION_INFRA_VERSION: "2.0.0-17"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -118,7 +118,7 @@ env:
   # SLACK_CHANNEL: "C05K2KF1UP8"
   PROJECT_DATA_VIEWER_API: "https://personal-7vf0v2cu.outsystemscloud.com/ProjectDataViewer5/rest/V1//CreateProject"
   MINIO_S3_URL: "https://s3.mov.ai"
-  PROVISIONING_ENV_VERSION: 0.1.0-17
+  PROVISIONING_ENV_VERSION: 0.2.0-2
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -121,7 +121,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   TIMEOUT: 720
-  PROVISIONING_ENV_VERSION: 0.1.0-17
+  PROVISIONING_ENV_VERSION: 0.2.0-2
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:
@@ -613,7 +613,8 @@ jobs:
         shell: bash
         run: |
           set -e
-          movai-cli apt_cache stop
+          movai-cli apt_cache stop || true
+          movai-cli apt_cache disable || true
 
           robots_str=$(movai-cli robots list)
           readarray -t robots <<< "$robots_str"

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -112,7 +112,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-16"
+  PROVISION_INFRA_VERSION: "2.0.0-17"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
   # development slack channel

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -72,7 +72,7 @@ env:
   JIRA_PASSWORD: ${{ secrets.jira_password}}
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-16"
+  PROVISION_INFRA_VERSION: "2.0.0-17"
   PROVISION_INFRA_DIR: "provision_scripts"
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -77,7 +77,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   PROVISIONING_ENV_CONF_REPO: "devops-tf-env-conf"
-  PROVISIONING_ENV_CONF_VERSION: "0.1.0-17"
+  PROVISIONING_ENV_CONF_VERSION: "0.2.0-2"
   PROVISION_ENV_CONF_DIR: "infra_env_configs"
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     - id: check-json                # checks if json files are valid
     - id: check-added-large-files   # checks if large files were added
@@ -12,7 +12,7 @@ repos:
       args: [--fix=lf]
     - id: trailing-whitespace       # removes trailing whitespaces from text files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: actionlint
         args:
@@ -26,3 +26,5 @@ repos:
           - 'label ".+" is unknown'
           - -ignore  # Ignore SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects
           - SC2129
+          - -ignore  # Ignore SC1083: This { is literal. Check expression (missing ;/\n?) or quote to prevent this.
+          - SC1083

--- a/workflows/DeployOnMergeMain.yaml
+++ b/workflows/DeployOnMergeMain.yaml
@@ -1,0 +1,66 @@
+name: Pre Release on merge to main
+
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+    paths-ignore:
+      - 'version'
+jobs:
+  Deploy:
+    timeout-minutes: 30
+    name: "Deploy Script"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: install raise requirements
+      run: python3 -m pip install -r build-requirements.txt
+
+    - name: Raise Version
+      id: vars-after-raise
+      run: |
+        bump2version revision --no-tag --no-commit
+        RAISED_PACKAGE_VERSION=$(./fleet_install.sh -v | cut -d 'v' -f 2)
+        echo ::set-output name=pkg_version::$RAISED_PACKAGE_VERSION
+
+    - name: Commit raise version
+      id: raise
+      run: |
+        git config --global user.name '${{ secrets.RAISE_BOT_COMMIT_USER }}'
+        git config --global user.email '${{ secrets.RAISE_BOT_COMMIT_MAIL }}'
+        git pull
+        git add .bumpversion.cfg fleet_install.sh
+        git commit -m "[skip actions] Automatic Bump of build version"
+
+    - name: Set branch output
+      id: var_branch
+      run: |
+        echo "Branch name is: ${GITHUB_REF#refs/heads/}"
+        echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
+    - name: Raise App version
+      uses: CasperWA/push-protected@v2.14.0
+      with:
+        token: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
+        branch: ${{ steps.var_branch.outputs.branch }}
+        unprotect_reviews: true
+
+    - name: Commit of version
+      id: commit_id
+      run: |
+        commit_hash=$(git log --format="%H" -n 1)
+        echo "commit_id=$commit_hash" >> $GITHUB_OUTPUT
+
+    - name: Create Github Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: "Release of ${{ steps.vars-after-raise.outputs.pkg_version }}"
+        body: "Please add release notes"
+        tag_name: ${{ steps.vars-after-raise.outputs.pkg_version }}
+        target_commitish: ${{ steps.commit_id.outputs.commit_id }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prerelease: true
+        generate_release_notes: true

--- a/workflows/TestOnPR.yaml
+++ b/workflows/TestOnPR.yaml
@@ -1,0 +1,53 @@
+name: Test on PR
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - dev
+      - 'releases/**'
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install pre-commit==3.7.1
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
+      - name: Install test dependencies
+        run: |
+          python3.10 -m venv molecule-venv
+          source molecule-venv/bin/activate
+          pip3 install -r test-requirements.txt
+          ansible-galaxy collection install -r requirements.yml
+          deactivate
+
+      - name: Run molecule
+        env:
+          MOLECULE_GLOB: 'roles/*/molecule/*/molecule.yml'
+        run: |
+          source molecule-venv/bin/activate
+          molecule test --all
+
+  RefreshSource:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.RAISE_BOT_COMMIT_USER }}'
+          MERGE_MSG: "Branch was auto-updated."


### PR DESCRIPTION
**v2.1 - bump devops-tf-proxmox-bpg to 2.0.0-17**

This pull request updates the version of the infrastructure provisioning dependency across several GitHub Actions workflow files. The main change is bumping the `PROVISION_INFRA_VERSION` from `2.0.0-16` (or `1.0.0-3` in one case) to `2.0.0-17` to ensure all workflows use the latest infrastructure scripts.

Dependency version updates:

* Updated `PROVISION_INFRA_VERSION` to `2.0.0-17` in the following workflow files: `.github/workflows/deploy-project.yml`, `.github/workflows/integration-build-product.yml`, `.github/workflows/integration-build-product-composite.yml`, and `.github/workflows/integration-robotic-stack-tests.yml`.

* Updated the `provision_infra_version` variable to `2.0.0-17` in `.github/workflows/integration-build-platform.yml` (previously `1.0.0-3`).
