### PR TITLE
Enhancement/fetch tests

### DIFF
--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -85,7 +85,7 @@ jobs:
                 --gh_api_user ${{ secrets.auto_commit_user }} \
                 --gh_api_pwd ${{ secrets.auto_commit_pwd }} \
                 --target_dir product
-          ls -la product/
+
           cp product/product-manifest.yaml product-manifest.yaml
 
       - name: calculate robot.json to use

--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -14,7 +14,7 @@ on:
       test_infra_key:
         required: false
         type: string
-        default: "local"
+        default: 'local'
       pytest_args:
         required: true
         type: string
@@ -161,7 +161,7 @@ jobs:
           retention-days: 5
 
       - name: Local Generic Tests - Setup
-        if: ${{ inputs.test_infra_key == "local" }}
+        if: ${{ inputs.test_infra_key == 'local' }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -175,7 +175,7 @@ jobs:
 
 
       - name: Fetched Tests - Setup ${{ inputs.test_infra_key }}
-        if: ${{ inputs.test_infra_key != "local" }}
+        if: ${{ inputs.test_infra_key != 'local' }}
         id: infra_tests_setup
         shell: bash
         env:
@@ -216,7 +216,7 @@ jobs:
           deactivate
 
       - name: Local Generic Tests - Run tests
-        if: ${{ inputs.test_infra_key == "local" }}
+        if: ${{ inputs.test_infra_key == 'local' }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -228,7 +228,7 @@ jobs:
           fi
 
       - name: Fetched Tests - Run tests
-        if: ${{ inputs.test_infra_key != "local" }}
+        if: ${{ inputs.test_infra_key != 'local' }}
         timeout-minutes: ${{ inputs.test_timeout }}
         working-directory: ${{ steps.infra_tests_setup.outputs.target_dir }}
         shell: bash
@@ -246,7 +246,7 @@ jobs:
           deactivate
 
       - name: Local Generic Tests - Collect tests artifacts
-        if: ${{ inputs.test_infra_key == "local" && always() }}
+        if: ${{ inputs.test_infra_key == 'local' && always() }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -258,7 +258,7 @@ jobs:
           fi
 
       - name: Fetched Tests - Collect tests artifacts
-        if: ${{ inputs.test_infra_key != "local" && always() }}
+        if: ${{ inputs.test_infra_key != 'local' && always() }}
         shell: bash
         env:
           TEST_INFRA_DIR: ${{ steps.infra_tests_setup.outputs.target_dir }}
@@ -293,14 +293,14 @@ jobs:
           journalctl -u movai-service -t mobros --since '1hour ago' &> spawner-firmware.log || true
 
       - name: Generic Tests - Publish test artifacts
-        if: ${{ inputs.test_infra_key == "local" && always() }}
+        if: ${{ inputs.test_infra_key == 'local' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test_artifacts
           path: test_artifacts
 
       - name: Fetched Tests - Publish test artifacts
-        if: ${{ inputs.test_infra_key != "local" && always() }}
+        if: ${{ inputs.test_infra_key != 'local' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.run_number }}_${{ github.run_attempt }}_${{inputs.test_infra_key}}_artifacts_${{ github.run_id }}

--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -11,6 +11,17 @@ on:
       download_artifact:
         required: false
         type: boolean
+      test_infra_key:
+        required: false
+        type: string
+        default: "local"
+      pytest_args:
+        required: true
+        type: string
+      test_timeout:
+        required: false
+        type: number
+        default: 60
 
     secrets:
       auto_commit_user:
@@ -31,6 +42,7 @@ env:
   GITHUB_API_USR: "OttoMation-Movai"
   USERSPACE_FOLDER_PATH: userspace
   REMOTE_WORKSPACE_PATH: workspace
+  ARTIFACTS_RETENTION_DAYS: 15
 
 jobs:
   Platform-tests:
@@ -39,6 +51,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Agent info
+        id: agent_info
+        run: |
+          echo "ip=$(hostname -I | awk '{print $1}')" | tee $GITHUB_OUTPUT
 
       - name: Install CI Scripts in container
         shell: bash
@@ -68,7 +85,7 @@ jobs:
                 --gh_api_user ${{ secrets.auto_commit_user }} \
                 --gh_api_pwd ${{ secrets.auto_commit_pwd }} \
                 --target_dir product
-
+          cp product/product-manifest.yml product-manifest.yml
 
       - name: calculate robot.json to use
         shell: bash
@@ -143,7 +160,8 @@ jobs:
           path: product
           retention-days: 5
 
-      - name: test setup
+      - name: Local Generic Tests - Setup
+        if: ${{ inputs.test_infra_key == "local" }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -155,7 +173,50 @@ jobs:
             . .github/workflows/test_setup.bash
           fi
 
-      - name: Run tests
+
+      - name: Fetched Tests - Setup ${{ inputs.test_infra_key }}
+        if: ${{ inputs.test_infra_key != "local" }}
+        id: infra_tests_setup
+        shell: bash
+        env:
+          qa_key: ${{ inputs.test_infra_key }}
+        run: |
+          mkdir -p test_artifacts
+          rm -f /tmp/target_dir.txt /tmp/version.txt /tmp/repo_name.txt /tmp/jira_report.txt /tmp/test_set.txt
+          . .ci-venv/bin/activate
+          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.target_dir --output_file /tmp/target_dir.txt
+          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.version --output_file /tmp/version.txt
+          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.name --output_file /tmp/repo_name.txt
+          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.jira_report --output_file /tmp/jira_report.txt
+          integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.test_set --output_file /tmp/test_set.txt
+          integration-pipeline get_yml_value --file product-manifest.yaml --key version --output_file /tmp/platform_version.txt
+
+          tests_dir=$(cat /tmp/target_dir.txt)
+          tests_version=$(cat /tmp/version.txt)
+          tests_repo_name=$(cat /tmp/repo_name.txt)
+          jira_report=$(cat /tmp/jira_report.txt)
+          test_set=$(cat /tmp/test_set.txt)
+          platform_version=$(cat /tmp/platform_version.txt)
+
+          rm -rf $tests_repo_name
+
+          integration-pipeline fetch_by_tag --repo $tests_repo_name --version $tests_version --gh_api_user $GITHUB_API_USR --gh_api_pwd ${{ secrets.auto_commit_pwd }} --target_dir $tests_dir
+          ls -la $tests_dir
+
+          echo "target_dir=${tests_dir}" >> $GITHUB_OUTPUT
+          echo "jira_report=${jira_report}" >> $GITHUB_OUTPUT
+          echo "test_set=${test_set}" >> $GITHUB_OUTPUT
+          echo "platform_version=${platform_version}" >> $GITHUB_OUTPUT
+          deactivate
+
+          # setup tests venv in a step that is always executed
+          python3 -m venv "${tests_dir}"/test-venv --clear
+          . "${tests_dir}"/test-venv/bin/activate
+          pip install -r "${tests_dir}"/requirements.txt
+          deactivate
+
+      - name: Local Generic Tests - Run tests
+        if: ${{ inputs.test_infra_key == "local" }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -166,8 +227,26 @@ jobs:
             . .github/workflows/run_tests.bash
           fi
 
-      - name: Collect tests artifacts
-        if: always()
+      - name: Fetched Tests - Run tests
+        if: ${{ inputs.test_infra_key != "local" }}
+        timeout-minutes: ${{ inputs.test_timeout }}
+        working-directory: ${{ steps.infra_tests_setup.outputs.target_dir }}
+        shell: bash
+        env:
+          selenoid_url: "http://selenoid-ui.hel.mov.ai"
+          host_ip: ${{ steps.agent_info.outputs.ip }}
+          movai_user: ${{ steps.install.outputs.movai_user }}
+          movai_pwd: ${{ steps.install.outputs.movai_pwd }}
+          test_set: ${{ steps.infra_tests_setup.outputs.test_set }}
+        run: |
+          . test-venv/bin/activate
+          pip install buildkite-test-collector
+          echo "python3 -m pytest ${{ inputs.pytest_args}}" 
+          python3 -m pytest ${{ inputs.pytest_args}} | tee pytest-output.log
+          deactivate
+
+      - name: Local Generic Tests - Collect tests artifacts
+        if: ${{ inputs.test_infra_key == "local" && always() }}
         shell: bash
         run: |
           export CONFIG_FILE_NAME=$(cat product/robot.json)
@@ -177,6 +256,22 @@ jobs:
             echo "Collecting tests artifacts"
             . .github/workflows/collect_tests_artifacts.bash
           fi
+
+      - name: Fetched Tests - Collect tests artifacts
+        if: ${{ inputs.test_infra_key != "local" && always() }}
+        shell: bash
+        env:
+          TEST_INFRA_DIR: ${{ steps.infra_tests_setup.outputs.target_dir }}
+        run: |
+          # cleanup
+          rm -rf qa_artifacts
+
+          # tests artifacts
+          # *.log and *.zip might not exist if the test fails early
+          mkdir -p qa_artifacts
+          cp -r "${TEST_INFRA_DIR}"/*.{log,tar,json,html} ./qa_artifacts 2>/dev/null || true
+          cp -r "${TEST_INFRA_DIR}"/tests_artifacts ./qa_artifacts || true
+
 
       - name: Collect platform artifacts
         if: always()
@@ -197,12 +292,20 @@ jobs:
           # spawner (mobros firmware)
           journalctl -u movai-service -t mobros --since '1hour ago' &> spawner-firmware.log || true
 
-      - name: Upload test_artifacts
-        if: always()
+      - name: Generic Tests - Publish test artifacts
+        if: ${{ inputs.test_infra_key == "local" && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test_artifacts
           path: test_artifacts
+
+      - name: Fetched Tests - Publish test artifacts
+        if: ${{ inputs.test_infra_key != "local" && always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_number }}_${{ github.run_attempt }}_${{inputs.test_infra_key}}_artifacts_${{ github.run_id }}
+          path: qa_artifacts/*
+          retention-days: ${{ env.ARTIFACTS_RETENTION_DAYS }}
 
       - name: Docker cleanups
         if: always()

--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -86,7 +86,7 @@ jobs:
                 --gh_api_pwd ${{ secrets.auto_commit_pwd }} \
                 --target_dir product
           ls -la product/
-          cp product/product-manifest.yml product-manifest.yml
+          cp product/product-manifest.yaml product-manifest.yaml
 
       - name: calculate robot.json to use
         shell: bash

--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -85,6 +85,7 @@ jobs:
                 --gh_api_user ${{ secrets.auto_commit_user }} \
                 --gh_api_pwd ${{ secrets.auto_commit_pwd }} \
                 --target_dir product
+          ls -la product/
           cp product/product-manifest.yml product-manifest.yml
 
       - name: calculate robot.json to use

--- a/.github/workflows/integration-build-component.yml
+++ b/.github/workflows/integration-build-component.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           mkdir -p test_artifacts
           rm -f /tmp/target_dir.txt /tmp/version.txt /tmp/repo_name.txt /tmp/jira_report.txt /tmp/test_set.txt
-          . .ci-venv/bin/activate
+          source ci_scripts/bin/activate
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.target_dir --output_file /tmp/target_dir.txt
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.version --output_file /tmp/version.txt
           integration-pipeline get_yml_value --file product-manifest.yaml --key product_components.qa.$qa_key.name --output_file /tmp/repo_name.txt


### PR DESCRIPTION
Enable the fetch of product pipeline tests to run in component pipeline.

With this it has 2 modes.
local: 
runs against local generic tests (generic being a run tests bash script)

a product key:
uses the manifest section with that key to run the tests of that type


Tested on: https://github.com/MOV-AI/frontend-npm-ide/actions/runs/18937634862