### PR TITLE
Feature: Add pre-commit step to ROS workflow

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -217,13 +217,8 @@ jobs:
       if: ${{ inputs.pre_commit }}
       run: |
         python3 -m pip install pre-commit pylint
-        # debug logs
-        echo Running pwd
-        pwd
-        echo Running ls
-        ls -la
         git config --global --add safe.directory $(pwd)
-        python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files
+        python3 -m pre_commit run pylint-postbuild --hook-stage manual --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -131,12 +131,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install yamllint -y
           python3 -m pip install pip --upgrade
-          python3 -m pip install pre-commit catkin_lint flake8
+          python3 -m pip install pre-commit catkin_lint pylint flake8
 
       - name: Run pre-commit
         run: |
           git config --global --add safe.directory $(pwd)
           SKIP=pylint python -m pre_commit run --show-diff-on-failure --color=always --all-files
+          python -m pre_commit run pylint --show-diff-on-failure --color=always --all-files --args="--disable=E0401"
 
   Build:
     strategy:
@@ -214,7 +215,8 @@ jobs:
 
     - name: Run pylint
       run: |
-        python -m pre_commit run pylint --show-diff-on-failure --color=always --all-files
+        python3 -m pip install pre-commit pylint
+        python3 -m pre_commit run pylint --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -96,6 +96,35 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.auto_commit_pwd }}'
           MERGE_MSG: "Branch was auto-updated."
 
+  Pre-commit:
+    if: ${{ inputs.pre_commit }}
+    runs-on: ubuntu-22.04
+    container:
+      image: registry.aws.cloud.mov.ai/qa/py-buildserver:v3.0.4
+      credentials:
+        username: ${{secrets.registry_user}}
+        password: ${{secrets.registry_password}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+
+      - name: Install dependencies and package
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple -r build-requirements.txt
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple .
+
+          python3 -m pip install pre-commit
+
+      - name: Run pre-commit
+        run: |
+          git config --global --add safe.directory $(pwd)
+          python -m pre_commit run --show-diff-on-failure --color=always --all-files
+
   Build:
     strategy:
       matrix:

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -101,6 +101,9 @@ jobs:
           MERGE_MSG: "Branch was auto-updated."
 
   Pre-commit:
+    strategy:
+      matrix:
+        distro: ${{ fromJSON(inputs.ros_distro) }}
     if: ${{ inputs.pre_commit }}
     runs-on: ubuntu-22.04
     container:

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -213,6 +213,7 @@ jobs:
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
     - name: Run pylint
+      if: ${{ inputs.pre_commit }}
       run: |
         python3 -m pip install pre-commit pylint
         python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -153,7 +153,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install yamllint -y
           python3 -m pip install pip --upgrade
-          python3 -m pip install pre-commit catkin_lint pylint flake8
+          python3 -m pip install -r ./requirements-dev.txt
 
       - name: Run pre-commit
         run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -217,6 +217,7 @@ jobs:
       if: ${{ inputs.pre_commit }}
       run: |
         python3 -m pip install pre-commit pylint
+        source /opt/ros/noetic/setup.bash
         git config --global --add safe.directory $(pwd)
         python3 -m pre_commit run pylint-postbuild --hook-stage manual --show-diff-on-failure --color=always --all-files
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -28,7 +28,7 @@ on:
       pre_commit:
         required: false
         type: boolean
-        default: false
+        default: true
       PYTHON_VERSION:
         required: false
         type: string
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         distro: ${{ fromJSON(inputs.ros_distro) }}
-    if: ${{ inputs.pre_commit }}
+    if: ${{ inputs.pre_commit && hashFiles('.pre-commit-config.yaml') != '' }}
     runs-on: ubuntu-22.04
     container:
       image: registry.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:${{ inputs.ROS_BUILDTOOLS_TAG }}
@@ -214,7 +214,7 @@ jobs:
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
     - name: Run pylint
-      if: ${{ inputs.pre_commit }}
+      if: ${{ inputs.pre_commit && hashFiles('.pre-commit-config.yaml') != '' }}
       shell: bash
       run: |
         python3 -m pip install pre-commit pylint

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -128,8 +128,10 @@ jobs:
 
       - name: Install dependencies and package
         run: |
+          sudo apt-get update
+          sudo apt-get install yamllint 
           python3 -m pip install pip --upgrade
-          python3 -m pip install pre-commit
+          python3 -m pip install pre-commit catkin_lint pylint
 
       - name: Run pre-commit
         run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -158,6 +158,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Validate Repository Package.xml
       run: |
@@ -220,7 +221,7 @@ jobs:
         echo Running pwd
         pwd
         echo Running ls
-        ls
+        ls -la
         python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -239,10 +239,13 @@ jobs:
       if: ${{ inputs.pre_commit && needs.Pre-commit.outputs.pre_commit_exists == 'true' }}
       shell: bash
       run: |
-        python3 -m pip install pre-commit pylint
-        source /opt/mov.ai/workspaces/USER_ROS1/setup.bash
-        git config --global --add safe.directory $(pwd)
-        python3 -m pre_commit run pylint-postbuild --hook-stage manual --show-diff-on-failure --color=always --all-files
+        HOOK_ID="pylint-postbuild"
+        if grep -q "id: $HOOK_ID" .pre-commit-config.yaml; then
+          python3 -m pip install pre-commit pylint
+          source /opt/mov.ai/workspaces/USER_ROS1/setup.bash
+          git config --global --add safe.directory $(pwd)
+          python3 -m pre_commit run pylint-postbuild --hook-stage manual --show-diff-on-failure --color=always --all-files
+        fi
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
 
-      - name: Install dependencies and package
+      - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install yamllint -y

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -104,24 +104,19 @@ jobs:
     if: ${{ inputs.pre_commit }}
     runs-on: ubuntu-22.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/py-buildserver:v3.0.4
+      image: registry.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:${{ inputs.ROS_BUILDTOOLS_TAG }}
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.PYTHON_VERSION }}
+          submodules: recursive
 
       - name: Install dependencies and package
         run: |
           python3 -m pip install pip --upgrade
-          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple -r build-requirements.txt
-          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple .
-
           python3 -m pip install pre-commit
 
       - name: Run pre-commit

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -216,6 +216,11 @@ jobs:
       if: ${{ inputs.pre_commit }}
       run: |
         python3 -m pip install pre-commit pylint
+        # debug logs
+        echo Running pwd
+        pwd
+        echo Running ls
+        ls
         python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -149,6 +149,7 @@ jobs:
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    needs: [Pre-commit]
 
     steps:
     - name: Checkout

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: boolean
         default: false
+      PYTHON_VERSION:
+        required: false
+        type: string
+        default: "3.8.10"
       run_catkin_tests:
         required: false
         type: boolean
@@ -117,6 +121,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
 
       - name: Install dependencies and package
         run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -215,6 +215,7 @@ jobs:
 
     - name: Run pylint
       if: ${{ inputs.pre_commit }}
+      shell: bash
       run: |
         python3 -m pip install pre-commit pylint
         source /opt/ros/noetic/setup.bash

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -218,7 +218,7 @@ jobs:
       shell: bash
       run: |
         python3 -m pip install pre-commit pylint
-        source /opt/ros/noetic/setup.bash
+        source /opt/mov.ai/workspaces/USER_ROS1/setup.bash
         git config --global --add safe.directory $(pwd)
         python3 -m pre_commit run pylint-postbuild --hook-stage manual --show-diff-on-failure --color=always --all-files
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -131,7 +131,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install yamllint -y
           python3 -m pip install pip --upgrade
-          python3 -m pip install pre-commit catkin_lint pylint
+          python3 -m pip install pre-commit catkin_lint flake8
 
       - name: Run pre-commit
         run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -136,8 +136,7 @@ jobs:
       - name: Run pre-commit
         run: |
           git config --global --add safe.directory $(pwd)
-          SKIP=pylint python -m pre_commit run --show-diff-on-failure --color=always --all-files
-          python -m pre_commit run pylint --show-diff-on-failure --color=always --all-files --args="--disable=E0401"
+          python -m pre_commit run --show-diff-on-failure --color=always --all-files
 
   Build:
     strategy:
@@ -216,7 +215,7 @@ jobs:
     - name: Run pylint
       run: |
         python3 -m pip install pre-commit pylint
-        python3 -m pre_commit run pylint --show-diff-on-failure --color=always --all-files
+        python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run pre-commit
         run: |
           git config --global --add safe.directory $(pwd)
-          python -m pre_commit run --show-diff-on-failure --color=always --all-files
+          SKIP=pylint python -m pre_commit run --show-diff-on-failure --color=always --all-files
 
   Build:
     strategy:

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -212,6 +212,10 @@ jobs:
         export MOVAI_OUTPUT_DIR="$(pwd)/artifacts"
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
+    - name: Run pylint
+      run: |
+        python -m pre_commit run pylint --show-diff-on-failure --color=always --all-files
+
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests }}
       shell: bash

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -222,6 +222,7 @@ jobs:
         pwd
         echo Running ls
         ls -la
+        git config --global --add safe.directory $(pwd)
         python3 -m pre_commit run pylint-postbuild --show-diff-on-failure --color=always --all-files
 
     - name: Run Catkin tests

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -104,11 +104,33 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.auto_commit_pwd }}'
           MERGE_MSG: "Branch was auto-updated."
 
+  Check-pre-commit:
+    if: ${{ inputs.pre_commit }}
+    outputs:
+      pre_commit_exists: ${{ steps.check.outputs.exists }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Check if pre-commit config exists
+        id: check
+        run: |
+          if [ -f ".pre-commit-config.yaml" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
   Pre-commit:
     strategy:
       matrix:
         distro: ${{ fromJSON(inputs.ros_distro) }}
-    if: ${{ inputs.pre_commit && hashFiles('.pre-commit-config.yaml') != '' }}
+    needs: [Check-pre-commit]
+    outputs:
+      pre_commit_exists: ${{ needs.Check-pre-commit.outputs.pre_commit_exists }}
+    if: ${{ inputs.pre_commit && needs.Check-pre-commit.outputs.pre_commit_exists == 'true' }}
     runs-on: ubuntu-22.04
     container:
       image: registry.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:${{ inputs.ROS_BUILDTOOLS_TAG }}
@@ -214,7 +236,7 @@ jobs:
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
     - name: Run pylint
-      if: ${{ inputs.pre_commit && hashFiles('.pre-commit-config.yaml') != '' }}
+      if: ${{ inputs.pre_commit && needs.Pre-commit.outputs.pre_commit_exists == 'true' }}
       shell: bash
       run: |
         python3 -m pip install pre-commit pylint

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -25,6 +25,10 @@ on:
         required: false
         type: string
         default: '["release"]'
+      pre_commit:
+        required: false
+        type: boolean
+        default: false
       run_catkin_tests:
         required: false
         type: boolean

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -143,7 +143,7 @@ jobs:
       matrix:
         distro: ${{ fromJSON(inputs.ros_distro) }}
         build_mode: ${{ fromJSON(inputs.build_modes) }}
-    if: ${{ inputs.release == 'false' }}
+    if: ${{ always() && inputs.release == 'false' && (needs.Pre-commit.result == 'success' || needs.Pre-commit.result == 'skipped') }}
     runs-on: ubuntu-22.04
     container:
       image: registry.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:${{ inputs.ROS_BUILDTOOLS_TAG }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: registry.cloud.mov.ai/qa/ros-buildtools-${{ matrix.distro }}:${{ inputs.ROS_BUILDTOOLS_TAG }}
+      options: --user root
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Install dependencies and package
         run: |
           sudo apt-get update
-          sudo apt-get install yamllint 
+          sudo apt-get install yamllint -y
           python3 -m pip install pip --upgrade
           python3 -m pip install pre-commit catkin_lint pylint
 


### PR DESCRIPTION
Added a pre-commit step to the workflow for dependency installation and code checks.

Tests:
- movai_scan: https://github.com/MOV-AI/movai_scan/actions/runs/19672539935
- movai_common: https://github.com/MOV-AI/movai_common/actions/runs/19672714682?pr=238
- movai_slam: https://github.com/MOV-AI/movai_slam/actions/runs/19672516060


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
