### PR TITLE
removed fleet tests from running in qa_ui pipeline since not fleet

### DIFF
--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -126,7 +126,8 @@ jobs:
             --hub_url ${{ inputs.selenoid_server_url }} \
             --base_url https://${{ steps.agent_info.outputs.ip }}/ \
             --install-platform \
-            | tee pytest-output.log
+            | tee pytest-output.log \
+            -m "not fleet"
 
       - name: Save docker container logs
         if: always()


### PR DESCRIPTION
Added `-m "not fleet"` flag to pytest command so we dont run fleet test in UI tests pipeline since its a standalone.
