### PR TITLE
v2.3 - ros-workflow: Change default value of run_stack_tests to false

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -78,7 +78,7 @@ on:
       run_stack_tests:
         required: false
         type: boolean
-        default: true
+        default: false
 
     secrets:
       auto_commit_user:


### PR DESCRIPTION
v2.3 of ros-workflow should not run stack test by default, movai_navigation should put this parameter to true