### PR TITLE
2.3 - Fix : Add handle_submodules_on_deploy input to control git pull behavior

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -79,6 +79,10 @@ on:
         required: false
         type: boolean
         default: false
+      handle_submodules_on_deploy:
+        required: false
+        type: string
+        default: "true"
 
     secrets:
       auto_commit_user:
@@ -455,12 +459,17 @@ jobs:
 
     - name: Commit raise version
       id: raise
+      shell: bash
       run: |
         git config --global --add safe.directory $(pwd)
         git config --global user.name '${{ secrets.auto_commit_user }}'
         git config --global user.email '${{ secrets.auto_commit_mail }}'
         git config --global user.password ${{ secrets.auto_commit_pwd }}
-        git pull
+        if [ "${{ inputs.handle_submodules_on_deploy }}" = "true" ]; then
+          git pull
+        else
+          git pull --no-recurse-submodules
+        fi
         git add **package.xml
         git commit -m "[skip actions] Automatic Bump of build version"
 


### PR DESCRIPTION
Fix error on: https://github.com/MOV-AI/rslidar_sdk_forked/actions/runs/20140567593/workflow

The error occurs because Git encounters historical submodule references that don't exist in the public GitHub repository. 

In the ros-workflow we need to use `git pull --no-recurse-submodules` to avoid automatic submodule updates failures

Note: Why Checkout Steps Don't Fail
- Different Behavior: actions/checkout@v4 with submodules: recursive behaves differently than git pull with submodules
- Fresh Clone: Checkout creates a fresh clone, so it doesn't encounter the historical submodule reference issues
GitHub's Handling: GitHub's checkout action handles submodule initialization more robustly than raw git commands
- Specific Problem: The error occurs specifically during git pull operations that try to update existing submodules, not during initial checkouts

Tested OK: https://github.com/MOV-AI/rslidar_sdk_forked/actions/runs/20142136556