### PR TITLE
v2.3 - Update Sonar actions

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -449,7 +449,7 @@ jobs:
         sonar_token: ${{ secrets.sonar_token }}
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v4.2.1
+      uses: SonarSource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ github.token }}
         SONAR_TOKEN: ${{ secrets.sonar_token }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -384,9 +384,9 @@ jobs:
 
       - name: SonarCloud Scan
         if: ${{ false }}
-        uses: SonarSource/sonarcloud-github-action@v1.8
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
-          GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.sonar_token }}
         with:
           projectBaseDir: ./

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -463,7 +463,7 @@ jobs:
         sonar_token: ${{ secrets.sonar_token }}
 
     - name: SonarCloud Scan and Quality Gate check
-      uses: SonarSource/sonarqube-scan-action@v4.2.1
+      uses: SonarSource/sonarqube-scan-action@v7
       if: ${{ inputs.skip_testing != 'true' }}
       env:
         GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any
@@ -487,7 +487,7 @@ jobs:
           -Dsonar.python.coverage.reportPaths=coverage.xml
 
     - name: SonarCloud Scan no Quality Gate check
-      uses: SonarSource/sonarcloud-github-action@v2.0.2
+      uses: SonarSource/sonarqube-scan-action@v7
       if: ${{ inputs.skip_testing == 'true' }}
       env:
         GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information, if any


### PR DESCRIPTION
Same as: #502 

This pull request updates the SonarCloud scanning actions used in several GitHub workflow files to ensure consistency and bring all jobs up to the latest supported version. The main change is switching all SonarCloud scan steps to use the unified `SonarSource/sonarqube-scan-action@v7` action, replacing older or deprecated versions.

**CI/CD Workflow Updates:**

* Updated `.github/workflows/py-workflow.yml` to use `SonarSource/sonarqube-scan-action@v7` for the SonarCloud scan step, replacing the previous `v4.2.1` version.
* Updated `.github/workflows/ros-workflow.yml` to use `SonarSource/sonarqube-scan-action@v7` instead of the older `sonarcloud-github-action@v1.8`.
* Updated `.github/workflows/service-py-deb-workflow.yml`:
  - Changed the SonarCloud Scan and Quality Gate check step to use `sonarqube-scan-action@v7` instead of `v4.2.1`.
  - Changed the SonarCloud Scan (no Quality Gate check) step to use `sonarqube-scan-action@v7` instead of `sonarcloud-github-action@v2.0.2`.

TESTED OK in :
- https://github.com/MOV-AI/movai-service/pull/621

