### PR TITLE
refactor: update push version changes step to use push-to-protected action

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -537,21 +537,14 @@ jobs:
           git config --global user.email "${{ secrets.commit_mail }}"
           bump-my-version bump patch --commit --tag
 
-#      - name: Commit and push version changes
-#        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
-#        uses: CasperWA/push-protected@v2
-#        with:
-#          token: ${{ secrets.commit_token }}
-#          branch: ${{ needs.raise-version.outputs.branch_name }}
-#          unprotect_reviews: true 
-
       - name: Push version bump to protected branch
         uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
+        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
         with:
-          token: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
-          git_user_email: ${{ secrets.RAISE_BOT_COMMIT_MAIL }}
-          git_user_name: ${{ secrets.RAISE_BOT_COMMIT_USER }}
-          branch: ${{ steps.var_branch.outputs.branch }}
+          token: ${{ secrets.commit_token }}
+          git_user_email: ${{ secrets.commit_mail }}
+          git_user_name: ${{ secrets.commit_user }}
+          branch: ${{ needs.raise-version.outputs.branch_name }}
           repository: ${{ github.repository }}
 
   create-release:

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -537,13 +537,22 @@ jobs:
           git config --global user.email "${{ secrets.commit_mail }}"
           bump-my-version bump patch --commit --tag
 
-      - name: Commit and push version changes
-        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
-        uses: CasperWA/push-protected@v2
+#      - name: Commit and push version changes
+#        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
+#        uses: CasperWA/push-protected@v2
+#        with:
+#          token: ${{ secrets.commit_token }}
+#          branch: ${{ needs.raise-version.outputs.branch_name }}
+#          unprotect_reviews: true 
+
+      - name: Push version bump to protected branch
+        uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
         with:
-          token: ${{ secrets.commit_token }}
-          branch: ${{ needs.raise-version.outputs.branch_name }}
-          unprotect_reviews: true
+          token: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
+          git_user_email: ${{ secrets.RAISE_BOT_COMMIT_MAIL }}
+          git_user_name: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+          branch: ${{ steps.var_branch.outputs.branch }}
+          repository: ${{ github.repository }}
 
   create-release:
     needs: [raise-version, publish]


### PR DESCRIPTION
Replacing the CasperWA/push-protected action with MOV-AI’s push-to-protected-branch action for pushing version bumps to protected branches. 