### PR TITLE
DP-2060 - fix v2.1: Update actions/checkout to v6 and configure git safe directory

### DIFF
--- a/.github/workflows/qa-install-workflow.yml
+++ b/.github/workflows/qa-install-workflow.yml
@@ -45,7 +45,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Feature file validation
         shell: bash
@@ -73,7 +76,10 @@ jobs:
         uses: rtCamp/action-cleanup@master
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Agent info
         id: agent_info


### PR DESCRIPTION
Updates actions/checkout to v6 and adds Git safe directory configuration to resolve "dubious ownership" error preventing pip install from accessing git-based version detection during the regression test workflow.