### PR TITLE
Refactor push to protected branch using shared action

### DIFF
--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -511,13 +511,15 @@ jobs:
         git config --global --add safe.directory $(pwd)
         git commit -am "[skip actions] Automatic Bump of build version to ${{ steps.bump.outputs.current_version }}"
 
-    - name: Raise App version
+    - name: Push version bump to protected branch
+      uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
       if: ${{ inputs.deploy }}
-      uses: CasperWA/push-protected@v2.14.0
       with:
         token: ${{ secrets.auto_commit_password }}
+        git_user_email: ${{ secrets.auto_commit_mail }}
+        git_user_name: ${{ secrets.auto_commit_user }}
         branch: ${{ needs.Pre-build.outputs.branch }}
-        unprotect_reviews: true
+        repository: ${{ github.repository }}
 
     - name: Commit of version
       if: ${{ inputs.deploy }}


### PR DESCRIPTION
This pull request updates the workflow for pushing version bumps to protected branches by switching to a new GitHub Action and improving configuration. The main focus is on enhancing the automation and security of version bump pushes during deployment.

**Workflow automation and configuration improvements:**

* Replaced the `CasperWA/push-protected@v2.14.0` action with the `MOV-AI/.github/.github/actions/push-to-protected-branch@v3` action for pushing version bumps to protected branches, aligning with internal tooling.
* Added configuration for `git_user_email` and `git_user_name` using repository secrets to ensure proper commit attribution.
* Added the `repository` parameter to explicitly specify the target repository for the push action.
* Removed the `unprotect_reviews` parameter, relying on the new action's default behavior.