### PR TITLE
[DP-2061] Replace Casper with push-to-protected-branch in shared workflow v3

### DIFF
--- a/.github/scripts/parse_docker_manifest.py
+++ b/.github/scripts/parse_docker_manifest.py
@@ -42,7 +42,9 @@ def parse_from_manifest(manifest_file, global_args):
         sys.exit(1)
 
     def get_val(img, key, global_val, default):
-        val = img[key] if key in img and img[key] is not None else global_val if global_val not in [None, ""] else default
+        val = (
+            img[key] if key in img and img[key] is not None else global_val if global_val not in [None, ""] else default
+        )
         if key in ["download_artifact", "push_latest", "public", "snyk_check"]:
             return normalize_bool(val)
         return val
@@ -61,8 +63,12 @@ def parse_from_manifest(manifest_file, global_args):
                 "build_args": get_val(img, "build_args", global_args["build_args"], ""),
                 "push_latest": get_val(img, "push_latest", global_args["push_latest"], False),
                 "download_artifact": get_val(img, "download_artifact", global_args["download_artifact"], False),
-                "download_artifact_name": get_val(img, "download_artifact_name", global_args["download_artifact_name"], "artifacts"),
-                "download_artifact_path": get_val(img, "download_artifact_path", global_args["download_artifact_path"], "./dist"),
+                "download_artifact_name": get_val(
+                    img, "download_artifact_name", global_args["download_artifact_name"], "artifacts"
+                ),
+                "download_artifact_path": get_val(
+                    img, "download_artifact_path", global_args["download_artifact_path"], "./dist"
+                ),
             }
             for img in images
         ]
@@ -247,11 +253,7 @@ def main():
     }
 
     # Determine which mode to use
-    outputs = (
-        parse_from_manifest(args.manifest_file, global_args)
-        if args.manifest_file
-        else parse_from_inputs(args)
-    )
+    outputs = parse_from_manifest(args.manifest_file, global_args) if args.manifest_file else parse_from_inputs(args)
 
     # Write outputs to GitHub Actions
     write_github_output(outputs)

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -544,13 +544,15 @@ jobs:
         echo "Branch name is: $BRANCH_NAME"
         echo "branch=$BRANCH_NAME" | tee -a "$GITHUB_OUTPUT"
 
-    - name: Push raised version
+    - name: Push version bump to protected branch
       if: ${{ inputs.deploy == 'true' }}
-      uses: CasperWA/push-protected@v2.16.0
+      uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
       with:
         token: ${{ secrets.auto_commit_password }}
+        git_user_email: ${{ secrets.auto_commit_mail }}
+        git_user_name: ${{ secrets.auto_commit_user }}
         branch: ${{ steps.var_branch.outputs.branch }}
-        unprotect_reviews: true
+        repository: ${{ github.repository }}
 
     - name: Store commit id of version
       if: ${{ inputs.deploy == 'true' }}


### PR DESCRIPTION
This pull request updates the workflow for pushing version bumps to protected branches by switching to a custom GitHub Action and improving configuration. The main change is the replacement of the third-party action with an in-house action, along with the addition of user and repository configuration options.

**Workflow action update:**

* Replaced the use of the `CasperWA/push-protected@v2.16.0` action with a custom `MOV-AI/.github/.github/actions/push-to-protected-branch@v3` action for pushing version bumps to protected branches. Added configuration for `git_user_email`, `git_user_name`, and `repository`, and removed the `unprotect_reviews` parameter. (`.github/workflows/service-py-deb-workflow.yml`)