### PR TITLE
[v3] Fix on installing 'jq' before checking branch protection

### DIFF
--- a/.github/actions/push-to-protected-branch/action.yml
+++ b/.github/actions/push-to-protected-branch/action.yml
@@ -67,6 +67,9 @@ runs:
         BRANCH="${{ inputs.branch }}"
         REPO="${{ inputs.repository }}"
 
+        echo "Installing pre-requirements..."
+        sudo apt-get update && sudo apt-get install -y jq
+
         echo "Checking branch protection configuration..."
 
         # Check for rulesets


### PR DESCRIPTION
Added installation of 'jq' as a prerequisite for the action.

This installation is necessary when running this action on the container ros-buildtools since this reuqirement doesn't exist there: https://github.com/MOV-AI/movai_navigation/actions/runs/23910723116/job/69732965126

Tested here: https://github.com/MOV-AI/movai_navigation/actions/runs/23912412570