### PR TITLE
Docker workflow creating prerelease

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -590,5 +590,5 @@ jobs:
           name: Release v${{ needs.raise-version.outputs.package_version }}
           body_path: release_body.md
           draft: false
-          prerelease: false
+          prerelease: true
           token: ${{ secrets.commit_token }}


### PR DESCRIPTION
- Docker workflow is not creating Github releases in prerelease, resulting in the execution of the release workflow in flow-initiator which is failing ATM
  - See https://github.com/MOV-AI/flow-initiator/actions/runs/24195220073
