### PR TITLE
DP-2079 : Add error handling of Fleet Provisioning for Fleet Teardown to happen even on failure

### DIFF
--- a/.github/workflows/integration-platform-remote-fleet-tests.yml
+++ b/.github/workflows/integration-platform-remote-fleet-tests.yml
@@ -252,18 +252,24 @@ jobs:
 
       - name: Stash provision_infra_dir
         uses: actions/upload-artifact@v4
+        if: always()
+        continue-on-error: true
         with:
           name: provision_infra_dir
           path: ${{ steps.provision_infra_setup.outputs.target_dir }}
 
       - name: Stash infra_env_configs
         uses: actions/upload-artifact@v4
+        if: always()
+        continue-on-error: true
         with:
           name: infra_env_configs
           path: ${{ steps.infra_env_configs_setup.outputs.target_dir }}
 
       - name: Stash provisioned_inventory
         uses: actions/upload-artifact@v4
+        if: always()
+        continue-on-error: true
         with:
           name: provisioned_inventory
           path: ${{ steps.provision_infra_setup.outputs.target_dir }}/provisioned_inventory.yml
@@ -574,19 +580,21 @@ jobs:
 
       - name: Unstash provision_infra_dir
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: provision_infra_dir
           path: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_provision_infra }}
 
       - name: Unstash infra_env_configs
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: infra_env_configs
           path: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_infra_env_configs }}
 
       - name: Teardown remote vms (Proxmox)
-        working-directory: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_provision_infra }}
-        if: ${{ ( !inputs.debug_fleet_keep_alive && success() ) || cancelled() || ( !inputs.debug_fleet_keep_alive && failure() ) }}
+        working-directory: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_provision_infra || '.' }}
+        if: ${{ needs.Fleet-Tests-Provisioning.result != 'skipped' && ( ( !inputs.debug_fleet_keep_alive && success() ) || cancelled() || ( !inputs.debug_fleet_keep_alive && failure() ) ) }}
         shell: bash
         run: |
           set +e

--- a/.github/workflows/integration-platform-remote-fleet-tests.yml
+++ b/.github/workflows/integration-platform-remote-fleet-tests.yml
@@ -593,7 +593,7 @@ jobs:
           path: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_infra_env_configs }}
 
       - name: Teardown remote vms (Proxmox)
-        working-directory: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_provision_infra || '.' }}
+        working-directory: ${{ needs.Fleet-Tests-Provisioning.outputs.target_dir_provision_infra }}
         if: ${{ needs.Fleet-Tests-Provisioning.result != 'skipped' && ( ( !inputs.debug_fleet_keep_alive && success() ) || cancelled() || ( !inputs.debug_fleet_keep_alive && failure() ) ) }}
         shell: bash
         run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/integration-platform-remote-fleet-tests.yml` workflow to improve the robustness and error handling of artifact upload and download steps, as well as to make the teardown step more resilient to missing directories and skipped jobs.

**Improvements to artifact handling and workflow robustness:**

* Added `if: always()` and `continue-on-error: true` to all `actions/upload-artifact@v4` steps to ensure artifacts are always attempted to be uploaded, even if previous steps fail, and to prevent workflow failures if artifact upload fails.
* Added `continue-on-error: true` to all `actions/download-artifact@v4` steps to prevent workflow failures if artifact download fails.

**Teardown step improvements:**

* Updated the working directory for the "Teardown remote vms (Proxmox)" step to default to `'.'` if the target directory is missing, and improved the conditional to skip this step only if the provisioning job was skipped.