### PR TITLE
v2.1: Update PROVISIONING_ENV_VERSION to 0.2.0-6 in multiple workflow files

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -98,7 +98,7 @@ env:
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   # development slack channel
   #SLACK_CHANNEL: "C05K2KF1UP8"
-  PROVISIONING_ENV_VERSION: 0.2.0-5
+  PROVISIONING_ENV_VERSION: 0.2.0-6
   PROVISIONING_ENV_REPO: devops-tf-env-conf
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
   PROVISION_INFRA_VERSION: "2.0.0-17"

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -98,7 +98,7 @@ env:
   SLACK_CHANNEL: "C02U028NMB7" # rnd-platform
   # development slack channel
   #SLACK_CHANNEL: "C05K2KF1UP8"
-  PROVISIONING_ENV_VERSION: 0.2.0-2
+  PROVISIONING_ENV_VERSION: 0.2.0-5
   PROVISIONING_ENV_REPO: devops-tf-env-conf
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
   PROVISION_INFRA_VERSION: "2.0.0-17"

--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -118,7 +118,7 @@ env:
   # SLACK_CHANNEL: "C05K2KF1UP8"
   PROJECT_DATA_VIEWER_API: "https://personal-7vf0v2cu.outsystemscloud.com/ProjectDataViewer5/rest/V1//CreateProject"
   MINIO_S3_URL: "https://s3.mov.ai"
-  PROVISIONING_ENV_VERSION: 0.2.0-2
+  PROVISIONING_ENV_VERSION: 0.2.0-5
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:

--- a/.github/workflows/integration-build-product-composite.yml
+++ b/.github/workflows/integration-build-product-composite.yml
@@ -118,7 +118,7 @@ env:
   # SLACK_CHANNEL: "C05K2KF1UP8"
   PROJECT_DATA_VIEWER_API: "https://personal-7vf0v2cu.outsystemscloud.com/ProjectDataViewer5/rest/V1//CreateProject"
   MINIO_S3_URL: "https://s3.mov.ai"
-  PROVISIONING_ENV_VERSION: 0.2.0-5
+  PROVISIONING_ENV_VERSION: 0.2.0-6
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -121,7 +121,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   TIMEOUT: 720
-  PROVISIONING_ENV_VERSION: 0.2.0-5
+  PROVISIONING_ENV_VERSION: 0.2.0-6
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -121,7 +121,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   TIMEOUT: 720
-  PROVISIONING_ENV_VERSION: 0.2.0-2
+  PROVISIONING_ENV_VERSION: 0.2.0-5
   PROVISIONING_ENV_REPO: devops-tf-env-conf
 
 jobs:

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -77,7 +77,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   PROVISIONING_ENV_CONF_REPO: "devops-tf-env-conf"
-  PROVISIONING_ENV_CONF_VERSION: "0.2.0-2"
+  PROVISIONING_ENV_CONF_VERSION: "0.2.0-5"
   PROVISION_ENV_CONF_DIR: "infra_env_configs"
 
 jobs:

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -77,7 +77,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   PROVISIONING_ENV_CONF_REPO: "devops-tf-env-conf"
-  PROVISIONING_ENV_CONF_VERSION: "0.2.0-5"
+  PROVISIONING_ENV_CONF_VERSION: "0.2.0-6"
   PROVISION_ENV_CONF_DIR: "infra_env_configs"
 
 jobs:


### PR DESCRIPTION
This pull request updates the provisioning environment configuration version used across several GitHub Actions workflows. The main purpose is to ensure all workflows use the latest version (`0.2.0-6`) of the provisioning environment configuration, which likely includes important fixes or improvements.

**Workflow configuration updates:**

* Updated `PROVISIONING_ENV_VERSION` from `0.2.0-2` to `0.2.0-6` in the following workflow files:
  - `.github/workflows/integration-build-platform.yml`
  - `.github/workflows/integration-build-product-composite.yml`
  - `.github/workflows/integration-build-product.yml`
* Updated `PROVISIONING_ENV_CONF_VERSION` from `0.2.0-2` to `0.2.0-6` in `.github/workflows/integration-robotic-stack-tests.yml`