### PR TITLE
Set DEBIAN_FRONTEND to noninteractive for upgrades

### DIFF
--- a/.github/workflows/qa-install-workflow.yml
+++ b/.github/workflows/qa-install-workflow.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Update/upgrade host packages
         run: |
+          export DEBIAN_FRONTEND=noninteractive
           while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ; do echo Waiting for other software managers to finish... ; sleep 5;done
           sudo apt-get update
           while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ; do echo Waiting for other software managers to finish... ; sleep 5;done

--- a/.github/workflows/qa-install-workflow.yml
+++ b/.github/workflows/qa-install-workflow.yml
@@ -93,7 +93,7 @@ jobs:
           while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ; do echo Waiting for other software managers to finish... ; sleep 5;done
           sudo apt-get update
           while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ; do echo Waiting for other software managers to finish... ; sleep 5;done
-          sudo apt-get upgrade -y
+          sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade -y
 
       - name: Setup venv
         shell: bash


### PR DESCRIPTION
This pull request makes a small improvement to the workflow for updating or upgrading host packages in the `.github/workflows/qa-install-workflow.yml` file. The change sets the `DEBIAN_FRONTEND` environment variable to `noninteractive` to prevent interactive prompts during package installation, ensuring smoother automation.

- Workflow reliability improvement:
  * Set `DEBIAN_FRONTEND=noninteractive` before running `apt-get update` to avoid interactive prompts during package operations in `.github/workflows/qa-install-workflow.yml`.