### PR TITLE
DP-2083 - Enforce setuptools version after Mobros installation to ensure ROS2 compatibility

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -280,11 +280,11 @@ jobs:
             exit 1
         fi
 
-    # --no-deps is used because all dependencies are already installed and pinned in the Docker image including a setuptools version compatible with ROS2/colcon
-    # Reinstalling dependencies here may override that setup and break ROS2 builds
     - name: Install Mobros
       run: |
-        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+        # pin setuptools version after mobros install to preserve ROS2/colcon compatibility
+        python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel
 
     - name: Setup link to Ros userspace
       run: |
@@ -405,7 +405,7 @@ jobs:
         run: |
           python3 -m pip install \
           -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple \
-          --no-deps mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
+          mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
 
       - name: Mobtest validations
         run: |
@@ -473,7 +473,7 @@ jobs:
         if: ${{ inputs.install_test }}
         run: |
           sudo apt update
-          python3 -m pip install --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+          python3 -m pip install mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
       - name: Install debian artifacts
         if: ${{ inputs.install_test }}
@@ -487,7 +487,7 @@ jobs:
         if: ${{ inputs.install_test }}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple --no-deps mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
           mobtest proj /opt/ros/${{ matrix.distro }}/share/
 
   Package-Stack-Tests:
@@ -537,7 +537,7 @@ jobs:
         ls -la .
 
     - name: Install Mobros
-      run: python3 -m pip install --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+      run: python3 -m pip install mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
     - name: Raise version and validate Ros repository
       run: mobros raise --workspace="$(pwd)"

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -364,6 +364,10 @@ jobs:
         name: packages
         path: artifacts
 
+    - name: Install Mobros
+      run: |
+        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+
     - name: Check package is installable
       shell: bash
       run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -282,7 +282,7 @@ jobs:
 
     - name: Install Mobros
       run: |
-        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
     - name: Setup link to Ros userspace
       run: |
@@ -399,7 +399,7 @@ jobs:
         run: |
           python3 -m pip install \
           -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple \
-          mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
+          --no-deps mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
 
       - name: Mobtest validations
         run: |
@@ -467,7 +467,7 @@ jobs:
         if: ${{ inputs.install_test }}
         run: |
           sudo apt update
-          python3 -m pip install mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+          python3 -m pip install --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
       - name: Install debian artifacts
         if: ${{ inputs.install_test }}
@@ -481,7 +481,7 @@ jobs:
         if: ${{ inputs.install_test }}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
+          python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple --no-deps mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
           mobtest proj /opt/ros/${{ matrix.distro }}/share/
 
   Package-Stack-Tests:
@@ -531,7 +531,7 @@ jobs:
         ls -la .
 
     - name: Install Mobros
-      run: python3 -m pip install mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+      run: python3 -m pip install --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
     - name: Raise version and validate Ros repository
       run: mobros raise --workspace="$(pwd)"

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -280,6 +280,8 @@ jobs:
             exit 1
         fi
 
+    # --no-deps is used because all dependencies are already installed and pinned in the Docker image including a setuptools version compatible with ROS2/colcon
+    # Reinstalling dependencies here may override that setup and break ROS2 builds
     - name: Install Mobros
       run: |
         python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -366,7 +366,7 @@ jobs:
 
     - name: Install Mobros
       run: |
-        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple --no-deps mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
+        python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
 
     - name: Check package is installable
       shell: bash


### PR DESCRIPTION
The build was failing with setuptools compatibility errors during the ROS2 package build phase

This happens because installing mobros dependencies can upgrade setuptools to versions that are incompatible with ROS2/colcon on Ubuntu Jammy causing distutils-related failures during colcon builds

Solution:

* Explicitly reinstall and pin a known-good setuptools range after dependency installation:
  `python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel`

This preserves compatibility with the ROS2 Python tooling while still allowing mobros and mobtest dependencies to be installed normally

Tested here: https://github.com/MOV-AI/movai_qa_platform_tests_ros2/pull/4
