### PR TITLE
DP-2110 & DP-2112: Check notes and versions of release

### DIFF
--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -466,16 +466,9 @@ jobs:
         # Get the current release notes
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
-        # Filter out unwanted PR messages and patterns
+        # Filter out temporary PR messages
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:" | \
-          grep -v -i "Temporary PR to bypass branch protection" | \
-          grep -v -i "Auto-merging after creation" | \
-          grep -v -i "Automated PR for" | \
-          grep -v -i "Automatic update" | \
-          grep -v -i "\[skip" | \
-          grep -v "^\* $" | \
-          sed '/^$/N;/^\n$/!P;D')
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
         # If filtering removed everything or resulted in empty content, keep original
         if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then

--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -433,14 +433,49 @@ jobs:
         commit_hash=$(git log --format="%H" -n 1)
         product_version=${{ steps.vars-after-raise.outputs.npm_pkg_version }}
         previous_version_option=""
-        if gh release view ${{ steps.vars.outputs.pkg_version }} &>/dev/null; then
-          previous_version_option="--notes-start-tag ${{ steps.vars.outputs.pkg_version }}"
+
+        # Find the previous release version to generate notes from correct range
+        previous_version=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases 2>/dev/null | awk 'NR>1 {print $2; exit}')
+
+        if [ -n "$previous_version" ] && [ "$previous_version" != "$product_version" ]; then
+          previous_version_option="--notes-start-tag $previous_version"
         fi
+
         gh release create -p --generate-notes $previous_version_option --target $commit_hash -t "Release of $product_version" $product_version
         # add all files in the artifacts folder
         find artifacts -type f -exec gh release upload $product_version {} \;
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+    - name: Filter Release Notes
+      shell: bash
+      run: |
+        product_version=${{ steps.vars-after-raise.outputs.npm_pkg_version }}
+
+        # Get the current release notes
+        current_notes=$(gh release view "$product_version" --json body --jq .body)
+
+        # Filter out unwanted PR messages and patterns
+        filtered_notes=$(echo "$current_notes" | \
+          grep -v -i "Temporary PR to bypass branch protection" | \
+          grep -v -i "Auto-merging after creation" | \
+          grep -v -i "Automated PR for" | \
+          grep -v -i "Automatic update" | \
+          grep -v -i "\[skip" | \
+          grep -v "^\* $" | \
+          sed '/^$/N;/^\n$/!P;D')
+
+        # If filtering removed everything or resulted in empty content, keep original
+        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
+          echo "No content left after filtering, keeping original release notes"
+        else
+          # Update the release with filtered notes
+          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+      continue-on-error: true
 
   Release:
     strategy:

--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -431,32 +431,44 @@ jobs:
       shell: bash
       run: |
         commit_hash=$(git log --format="%H" -n 1)
-        product_version=${{ steps.vars-after-raise.outputs.npm_pkg_version }}
+        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
+
+        # get previous release tag
+        previous_tag=$(gh release list \
+          --limit 2 \
+          --json tagName \
+          --jq '.[1].tagName')
+
+        echo "Previous tag: $previous_tag"
+
         previous_version_option=""
-
-        # Find the previous release version to generate notes from correct range
-        previous_version=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases 2>/dev/null | awk 'NR>1 {print $2; exit}')
-
-        if [ -n "$previous_version" ] && [ "$previous_version" != "$product_version" ]; then
-          previous_version_option="--notes-start-tag $previous_version"
+        if [ -n "$previous_tag" ]; then
+          previous_version_option="--notes-start-tag $previous_tag"
         fi
 
-        gh release create -p --generate-notes $previous_version_option --target $commit_hash -t "Release of $product_version" $product_version
-        # add all files in the artifacts folder
-        find artifacts -type f -exec gh release upload $product_version {} \;
+        gh release create \
+          -p \
+          --generate-notes \
+          $previous_version_option \
+          --target "$commit_hash" \
+          -t "Release of $product_version" \
+          "$product_version"
+
+        find artifacts -type f -exec gh release upload "$product_version" {} \;
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
 
     - name: Filter Release Notes
       shell: bash
       run: |
-        product_version=${{ steps.vars-after-raise.outputs.npm_pkg_version }}
+        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
 
         # Get the current release notes
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
         # Filter out unwanted PR messages and patterns
         filtered_notes=$(echo "$current_notes" | \
+          grep -v -E -i "Temporary PR:" | \
           grep -v -i "Temporary PR to bypass branch protection" | \
           grep -v -i "Auto-merging after creation" | \
           grep -v -i "Automated PR for" | \

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -857,9 +857,23 @@ jobs:
               # no PRs exist
               echo "No relevant changes." >> notes.txt
           else
-              # PRs exist
+              # PRs exist - filter out unwanted messages
               for pr in "${PRS[@]}"; do
-                  gh pr view "${pr}" --json body | jq -r .body >> notes.txt
+                  pr_body=$(gh pr view "${pr}" --json body | jq -r .body)
+
+                  # Filter out unwanted patterns
+                  filtered_body=$(echo "$pr_body" | \
+                    grep -v -i "Temporary PR to bypass branch protection" | \
+                    grep -v -i "Auto-merging after creation" | \
+                    grep -v -i "Automated PR for" | \
+                    grep -v -i "Automatic update" | \
+                    grep -v -i "\[skip" | \
+                    sed '/^[[:space:]]*$/d')
+
+                  # Only add if there's content left after filtering
+                  if [ -n "$filtered_body" ]; then
+                    echo "$filtered_body" >> notes.txt
+                  fi
               done
           fi
           echo "" >> notes.txt
@@ -870,8 +884,18 @@ jobs:
               # no PRs exist
               echo "No PRs." >> notes.txt
           else
-              # PRs exist
-              echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" >> notes.txt
+              # PRs exist - also filter here
+              pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
+                grep -v -i "Temporary PR to bypass branch protection" | \
+                grep -v -i "Auto-merging after creation" | \
+                grep -v -i "Automated PR for" | \
+                grep -v -i "Automatic update")
+
+              if [ -n "$pr_list" ]; then
+                echo "$pr_list" >> notes.txt
+              else
+                echo "No relevant PRs to display." >> notes.txt
+              fi
           fi
           echo "" >> notes.txt
 

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -863,6 +863,7 @@ jobs:
 
                   # Filter out unwanted patterns
                   filtered_body=$(echo "$pr_body" | \
+                    grep -v -E -i "Temporary PR:" | \
                     grep -v -i "Temporary PR to bypass branch protection" | \
                     grep -v -i "Auto-merging after creation" | \
                     grep -v -i "Automated PR for" | \
@@ -886,6 +887,7 @@ jobs:
           else
               # PRs exist - also filter here
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
+                grep -v -E -i "Temporary PR:" | \
                 grep -v -i "Temporary PR to bypass branch protection" | \
                 grep -v -i "Auto-merging after creation" | \
                 grep -v -i "Automated PR for" | \

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -861,14 +861,8 @@ jobs:
               for pr in "${PRS[@]}"; do
                   pr_body=$(gh pr view "${pr}" --json body | jq -r .body)
 
-                  # Filter out unwanted patterns
                   filtered_body=$(echo "$pr_body" | \
-                    grep -v -E -i "Temporary PR:" | \
-                    grep -v -i "Temporary PR to bypass branch protection" | \
-                    grep -v -i "Auto-merging after creation" | \
-                    grep -v -i "Automated PR for" | \
-                    grep -v -i "Automatic update" | \
-                    grep -v -i "\[skip" | \
+                    grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" | \
                     sed '/^[[:space:]]*$/d')
 
                   # Only add if there's content left after filtering
@@ -887,11 +881,7 @@ jobs:
           else
               # PRs exist - also filter here
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
-                grep -v -E -i "Temporary PR:" | \
-                grep -v -i "Temporary PR to bypass branch protection" | \
-                grep -v -i "Auto-merging after creation" | \
-                grep -v -i "Automated PR for" | \
-                grep -v -i "Automatic update")
+                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
               if [ -n "$pr_list" ]; then
                 echo "$pr_list" >> notes.txt

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2386,18 +2386,12 @@ jobs:
               # no PRs exist
               echo "No relevant changes." >> notes.txt
           else
-              # PRs exist - filter out unwanted messages
+                # PRs exist - filter out temporary PR messages
               for pr in "${PRS[@]}"; do
                   pr_body=$(gh pr view "${pr}" --json body | jq -r .body)
 
-                  # Filter out unwanted patterns
                   filtered_body=$(echo "$pr_body" | \
-                    grep -v -E -i "Temporary PR:" | \
-                    grep -v -i "Temporary PR to bypass branch protection" | \
-                    grep -v -i "Auto-merging after creation" | \
-                    grep -v -i "Automated PR for" | \
-                    grep -v -i "Automatic update" | \
-                    grep -v -i "\[skip" | \
+                  grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" | \
                     sed '/^[[:space:]]*$/d')
 
                   # Only add if there's content left after filtering
@@ -2411,16 +2405,10 @@ jobs:
           # PRs
           echo "## PRs" >> notes.txt
           if [ ${#PRS[@]} -eq 0 ]; then
-              # no PRs exist
               echo "No PRs." >> notes.txt
           else
-              # PRs exist - also filter here
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
-                grep -v -E -i "Temporary PR:" | \
-                grep -v -i "Temporary PR to bypass branch protection" | \
-                grep -v -i "Auto-merging after creation" | \
-                grep -v -i "Automated PR for" | \
-                grep -v -i "Automatic update")
+                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
               if [ -n "$pr_list" ]; then
                 echo "$pr_list" >> notes.txt

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2386,9 +2386,23 @@ jobs:
               # no PRs exist
               echo "No relevant changes." >> notes.txt
           else
-              # PRs exist
+              # PRs exist - filter out unwanted messages
               for pr in "${PRS[@]}"; do
-                  gh pr view "${pr}" --json body | jq -r .body >> notes.txt
+                  pr_body=$(gh pr view "${pr}" --json body | jq -r .body)
+
+                  # Filter out unwanted patterns
+                  filtered_body=$(echo "$pr_body" | \
+                    grep -v -i "Temporary PR to bypass branch protection" | \
+                    grep -v -i "Auto-merging after creation" | \
+                    grep -v -i "Automated PR for" | \
+                    grep -v -i "Automatic update" | \
+                    grep -v -i "\[skip" | \
+                    sed '/^[[:space:]]*$/d')
+
+                  # Only add if there's content left after filtering
+                  if [ -n "$filtered_body" ]; then
+                    echo "$filtered_body" >> notes.txt
+                  fi
               done
           fi
           echo "" >> notes.txt
@@ -2399,8 +2413,18 @@ jobs:
               # no PRs exist
               echo "No PRs." >> notes.txt
           else
-              # PRs exist
-              echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" >> notes.txt
+              # PRs exist - also filter here
+              pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
+                grep -v -i "Temporary PR to bypass branch protection" | \
+                grep -v -i "Auto-merging after creation" | \
+                grep -v -i "Automated PR for" | \
+                grep -v -i "Automatic update")
+
+              if [ -n "$pr_list" ]; then
+                echo "$pr_list" >> notes.txt
+              else
+                echo "No relevant PRs to display." >> notes.txt
+              fi
           fi
           echo "" >> notes.txt
 

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2392,6 +2392,7 @@ jobs:
 
                   # Filter out unwanted patterns
                   filtered_body=$(echo "$pr_body" | \
+                    grep -v -E -i "Temporary PR:" | \
                     grep -v -i "Temporary PR to bypass branch protection" | \
                     grep -v -i "Auto-merging after creation" | \
                     grep -v -i "Automated PR for" | \
@@ -2415,6 +2416,7 @@ jobs:
           else
               # PRs exist - also filter here
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
+                grep -v -E -i "Temporary PR:" | \
                 grep -v -i "Temporary PR to bypass branch protection" | \
                 grep -v -i "Auto-merging after creation" | \
                 grep -v -i "Automated PR for" | \

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -549,6 +549,37 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+    - name: Filter Release Notes
+      if: ${{ inputs.deploy }}
+      shell: bash
+      run: |
+        product_version="${{ steps.bump.outputs.current_version }}"
+
+        # Get the current release notes
+        current_notes=$(gh release view "$product_version" --json body --jq .body)
+
+        # Filter out unwanted PR messages and patterns
+        filtered_notes=$(echo "$current_notes" | \
+          grep -v -i "Temporary PR to bypass branch protection" | \
+          grep -v -i "Auto-merging after creation" | \
+          grep -v -i "Automated PR for" | \
+          grep -v -i "Automatic update" | \
+          grep -v -i "\[skip" | \
+          grep -v "^\* $" | \
+          sed '/^$/N;/^\n$/!P;D')
+
+        # If filtering removed everything or resulted in empty content, keep original
+        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
+          echo "No content left after filtering, keeping original release notes"
+        else
+          # Update the release with filtered notes
+          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+      continue-on-error: true
+
   Release:
     strategy:
       matrix:

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -550,16 +550,16 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
 
     - name: Filter Release Notes
-      if: ${{ inputs.deploy }}
       shell: bash
       run: |
-        product_version="${{ steps.bump.outputs.current_version }}"
+        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
 
         # Get the current release notes
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
         # Filter out unwanted PR messages and patterns
         filtered_notes=$(echo "$current_notes" | \
+          grep -v -E -i "Temporary PR:" | \
           grep -v -i "Temporary PR to bypass branch protection" | \
           grep -v -i "Auto-merging after creation" | \
           grep -v -i "Automated PR for" | \

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -554,19 +554,10 @@ jobs:
       run: |
         product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
 
-        # Get the current release notes
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
-        # Filter out unwanted PR messages and patterns
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:" | \
-          grep -v -i "Temporary PR to bypass branch protection" | \
-          grep -v -i "Auto-merging after creation" | \
-          grep -v -i "Automated PR for" | \
-          grep -v -i "Automatic update" | \
-          grep -v -i "\[skip" | \
-          grep -v "^\* $" | \
-          sed '/^$/N;/^\n$/!P;D')
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
         # If filtering removed everything or resulted in empty content, keep original
         if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -611,6 +611,36 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+    - name: Filter Release Notes
+      shell: bash
+      run: |
+        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
+
+        # Get the current release notes
+        current_notes=$(gh release view "$product_version" --json body --jq .body)
+
+        # Filter out unwanted PR messages and patterns
+        filtered_notes=$(echo "$current_notes" | \
+          grep -v -i "Temporary PR to bypass branch protection" | \
+          grep -v -i "Auto-merging after creation" | \
+          grep -v -i "Automated PR for" | \
+          grep -v -i "Automatic update" | \
+          grep -v -i "\[skip" | \
+          grep -v "^\* $" | \
+          sed '/^$/N;/^\n$/!P;D')
+
+        # If filtering removed everything or resulted in empty content, keep original
+        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
+          echo "No content left after filtering, keeping original release notes"
+        else
+          # Update the release with filtered notes
+          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+      continue-on-error: true
+
     - name: Propagate release
       if: ${{ inputs.propagate_to_projects }}
       continue-on-error: true

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -586,14 +586,48 @@ jobs:
         commit_hash=$(git log --format="%H" -n 1)
         product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
         previous_version_option=""
-        if gh release view ${{ steps.vars-after-raise.outputs.ros_pkg_version }} &>/dev/null; then
-          previous_version_option="--notes-start-tag ${{ steps.vars-after-raise.outputs.ros_pkg_version }}"
+
+        # Find the previous release version to generate notes from correct range
+        previous_version=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases 2>/dev/null | awk 'NR>1 {print $2; exit}')
+
+        if [ -n "$previous_version" ] && [ "$previous_version" != "$product_version" ]; then
+          previous_version_option="--notes-start-tag $previous_version"
         fi
         gh release create -p --generate-notes $previous_version_option --target $commit_hash -t "Release of $product_version" $product_version
         # add all files in the artifacts folder
         find artifacts -type f -exec gh release upload $product_version {} \;
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+    - name: Filter Release Notes
+      shell: bash
+      run: |
+        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
+
+        # Get the current release notes
+        current_notes=$(gh release view "$product_version" --json body --jq .body)
+
+        # Filter out unwanted PR messages and patterns
+        filtered_notes=$(echo "$current_notes" | \
+          grep -v -i "Temporary PR to bypass branch protection" | \
+          grep -v -i "Auto-merging after creation" | \
+          grep -v -i "Automated PR for" | \
+          grep -v -i "Automatic update" | \
+          grep -v -i "\[skip" | \
+          grep -v "^\* $" | \
+          sed '/^$/N;/^\n$/!P;D')
+
+        # If filtering removed everything or resulted in empty content, keep original
+        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
+          echo "No content left after filtering, keeping original release notes"
+        else
+          # Update the release with filtered notes
+          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+      continue-on-error: true
 
     - name: Propagate release
       if: ${{ inputs.propagate_to_projects }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -585,49 +585,31 @@ jobs:
       run: |
         commit_hash=$(git log --format="%H" -n 1)
         product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
+
+        # get previous release tag
+        previous_tag=$(gh release list \
+          --limit 2 \
+          --json tagName \
+          --jq '.[1].tagName')
+
+        echo "Previous tag: $previous_tag"
+
         previous_version_option=""
-
-        # Find the previous release version to generate notes from correct range
-        previous_version=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases 2>/dev/null | awk 'NR>1 {print $2; exit}')
-
-        if [ -n "$previous_version" ] && [ "$previous_version" != "$product_version" ]; then
-          previous_version_option="--notes-start-tag $previous_version"
+        if [ -n "$previous_tag" ]; then
+          previous_version_option="--notes-start-tag $previous_tag"
         fi
-        gh release create -p --generate-notes $previous_version_option --target $commit_hash -t "Release of $product_version" $product_version
-        # add all files in the artifacts folder
-        find artifacts -type f -exec gh release upload $product_version {} \;
+
+        gh release create \
+          -p \
+          --generate-notes \
+          $previous_version_option \
+          --target "$commit_hash" \
+          -t "Release of $product_version" \
+          "$product_version"
+
+        find artifacts -type f -exec gh release upload "$product_version" {} \;
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
-
-    - name: Filter Release Notes
-      shell: bash
-      run: |
-        product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
-
-        # Get the current release notes
-        current_notes=$(gh release view "$product_version" --json body --jq .body)
-
-        # Filter out unwanted PR messages and patterns
-        filtered_notes=$(echo "$current_notes" | \
-          grep -v -i "Temporary PR to bypass branch protection" | \
-          grep -v -i "Auto-merging after creation" | \
-          grep -v -i "Automated PR for" | \
-          grep -v -i "Automatic update" | \
-          grep -v -i "\[skip" | \
-          grep -v "^\* $" | \
-          sed '/^$/N;/^\n$/!P;D')
-
-        # If filtering removed everything or resulted in empty content, keep original
-        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
-          echo "No content left after filtering, keeping original release notes"
-        else
-          # Update the release with filtered notes
-          echo "$filtered_notes" > /tmp/filtered_notes.txt
-          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.gh_token }}
-      continue-on-error: true
 
     - name: Propagate release
       if: ${{ inputs.propagate_to_projects }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -616,19 +616,10 @@ jobs:
       run: |
         product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
 
-        # Get the current release notes
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
-        # Filter out unwanted PR messages and patterns
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:" | \
-          grep -v -i "Temporary PR to bypass branch protection" | \
-          grep -v -i "Auto-merging after creation" | \
-          grep -v -i "Automated PR for" | \
-          grep -v -i "Automatic update" | \
-          grep -v -i "\[skip" | \
-          grep -v "^\* $" | \
-          sed '/^$/N;/^\n$/!P;D')
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
         # If filtering removed everything or resulted in empty content, keep original
         if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -621,6 +621,7 @@ jobs:
 
         # Filter out unwanted PR messages and patterns
         filtered_notes=$(echo "$current_notes" | \
+          grep -v -E -i "Temporary PR:" | \
           grep -v -i "Temporary PR to bypass branch protection" | \
           grep -v -i "Auto-merging after creation" | \
           grep -v -i "Automated PR for" | \

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -806,13 +806,14 @@ jobs:
       - name: Filter Release Notes
         shell: bash
         run: |
-          product_version="${{ needs.Raise.outputs.package_version }}"
+          product_version=${{ steps.vars-after-raise.outputs.ros_pkg_version }}
 
           # Get the current release notes
           current_notes=$(gh release view "$product_version" --json body --jq .body)
 
           # Filter out unwanted PR messages and patterns
           filtered_notes=$(echo "$current_notes" | \
+            grep -v -E -i "Temporary PR:" | \
             grep -v -i "Temporary PR to bypass branch protection" | \
             grep -v -i "Auto-merging after creation" | \
             grep -v -i "Automated PR for" | \

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -803,6 +803,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+      - name: Filter Release Notes
+        shell: bash
+        run: |
+          product_version="${{ needs.Raise.outputs.package_version }}"
+
+          # Get the current release notes
+          current_notes=$(gh release view "$product_version" --json body --jq .body)
+
+          # Filter out unwanted PR messages and patterns
+          filtered_notes=$(echo "$current_notes" | \
+            grep -v -i "Temporary PR to bypass branch protection" | \
+            grep -v -i "Auto-merging after creation" | \
+            grep -v -i "Automated PR for" | \
+            grep -v -i "Automatic update" | \
+            grep -v -i "\[skip" | \
+            grep -v "^\* $" | \
+            sed '/^$/N;/^\n$/!P;D')
+
+          # If filtering removed everything or resulted in empty content, keep original
+          if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
+            echo "No content left after filtering, keeping original release notes"
+          else
+            # Update the release with filtered notes
+            echo "$filtered_notes" > /tmp/filtered_notes.txt
+            gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
+        continue-on-error: true
+
   Github-Release-Packages-Upload:
     needs: [Raise, Github-Release]
     runs-on: ubuntu-22.04

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -811,16 +811,8 @@ jobs:
           # Get the current release notes
           current_notes=$(gh release view "$product_version" --json body --jq .body)
 
-          # Filter out unwanted PR messages and patterns
           filtered_notes=$(echo "$current_notes" | \
-            grep -v -E -i "Temporary PR:" | \
-            grep -v -i "Temporary PR to bypass branch protection" | \
-            grep -v -i "Auto-merging after creation" | \
-            grep -v -i "Automated PR for" | \
-            grep -v -i "Automatic update" | \
-            grep -v -i "\[skip" | \
-            grep -v "^\* $" | \
-            sed '/^$/N;/^\n$/!P;D')
+            grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
 
           # If filtering removed everything or resulted in empty content, keep original
           if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then


### PR DESCRIPTION
This pull request focuses on improving the quality and relevance of automatically generated release notes across multiple CI workflows. The main enhancements involve filtering out boilerplate or uninformative PR messages from release notes and ensuring the correct range of changes is captured between releases. These changes help make release notes more concise and useful for end users and developers.

Key improvements include:

**Release Notes Filtering:**

* Added post-processing steps in several workflows (`frontend-monorepo-workflow.yml`, `ros-workflow.yml`, `py-workflow.yml`, `service-py-deb-workflow.yml`) to filter out unwanted PR messages and patterns (such as "Temporary PR to bypass branch protection", "Automated PR for", etc.) from release notes. If filtering removes all content, the original notes are retained. [[1]](diffhunk://#diff-145447b2e720e4104cc3498d74de14cb81007c3337ad8f2b353b669b75a3db4eL436-R479) [[2]](diffhunk://#diff-84e2a093673745a3f2959e4cce86234e2656a3899efb6d77bda179858622aec7L589-R631) [[3]](diffhunk://#diff-d7df1e2532a01f4d822274337233099d750aad05b80c8ffc73d25ca29b6c18a9R552-R582) [[4]](diffhunk://#diff-30fa89c75c2711790e8d495fde1f2e6dc79b0ca19998ea224bb911c05f47bf83R806-R835)

* Enhanced integration build workflows (`integration-build-platform.yml`, `integration-build-product.yml`) to filter out unwanted messages from both individual PR bodies and the summarized PR list in release notes, ensuring only relevant PRs and changes are included. [[1]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535L860-R876) [[2]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535L873-R898) [[3]](diffhunk://#diff-bfbc34c7422e454a0711853cff89419314a75ba02364b4ceb1d4ba7f278b8e2eL2389-R2405) [[4]](diffhunk://#diff-bfbc34c7422e454a0711853cff89419314a75ba02364b4ceb1d4ba7f278b8e2eL2402-R2427)

**Release Range Accuracy:**

* Improved logic for determining the correct previous release version in `frontend-monorepo-workflow.yml` and `ros-workflow.yml`, so that generated release notes accurately reflect the changes since the last actual release (excluding drafts and pre-releases). [[1]](diffhunk://#diff-145447b2e720e4104cc3498d74de14cb81007c3337ad8f2b353b669b75a3db4eL436-R479) [[2]](diffhunk://#diff-84e2a093673745a3f2959e4cce86234e2656a3899efb6d77bda179858622aec7L589-R631)

These updates collectively ensure that release notes are cleaner, more informative, and easier to read, while also reducing noise from automated or irrelevant PRs.

Tested here: https://github.com/MOV-AI/movai_navigation/releases