### PR TITLE
DP-2126: Add step to sync branch with remote before protected push

### DIFF
--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -398,6 +398,12 @@ jobs:
       run: |
         echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
+    - name: Sync branch with remote before protected push
+      run: |
+        BRANCH="${{ steps.pre_raise.outputs.branch }}"
+        git fetch origin "$BRANCH"
+        git pull --rebase origin "$BRANCH"
+
     - name: Raise App version
       uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
       with:

--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -402,7 +402,7 @@ jobs:
       run: |
         BRANCH="${{ steps.pre_raise.outputs.branch }}"
         git fetch origin "$BRANCH"
-        git pull --rebase origin "$BRANCH"
+        git pull origin "$BRANCH"
 
     - name: Raise App version
       uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3


### PR DESCRIPTION
When the local branch is behind the remote, push-to-protected-branch fails with a non-fast-forward error.

- Fix: Pull/rebase the latest remote changes before calling push-to-protected-branch to ensure the branch is up to date before pushing.

Related to: https://github.com/MOV-AI/.github/pull/556

Issue: https://github.com/MOV-AI/frontend-monorepo/actions/runs/26566276320/job/78262276795#step:12:241