### PR TITLE
Fix/DP-2126: Prevent release notes filtering from failing on empty PRs

### DIFF
--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -474,14 +474,16 @@ jobs:
 
         # Filter out temporary PR messages
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
-        # If filtering removed everything or resulted in empty content, keep original
-        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
-          echo "No content left after filtering, keeping original release notes"
+        # Keep only non-empty lines for emptiness checks
+        non_empty_filtered=$(echo "$filtered_notes" | sed '/^[[:space:]]*$/d')
+
+        if [ -z "$non_empty_filtered" ]; then
+          echo "No relevant changes." > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         else
-          # Update the release with filtered notes
-          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          echo "$non_empty_filtered" > /tmp/filtered_notes.txt
           gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         fi
       env:

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -862,8 +862,8 @@ jobs:
                   pr_body=$(gh pr view "${pr}" --json body | jq -r .body)
 
                   filtered_body=$(echo "$pr_body" | \
-                    grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" | \
-                    sed '/^[[:space:]]*$/d')
+                  grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" | \
+                    sed '/^[[:space:]]*$/d' || true)
 
                   # Only add if there's content left after filtering
                   if [ -n "$filtered_body" ]; then
@@ -876,12 +876,10 @@ jobs:
           # PRs
           echo "## PRs" >> notes.txt
           if [ ${#PRS[@]} -eq 0 ]; then
-              # no PRs exist
               echo "No PRs." >> notes.txt
           else
-              # PRs exist - also filter here
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
-                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
               if [ -n "$pr_list" ]; then
                 echo "$pr_list" >> notes.txt
@@ -893,7 +891,7 @@ jobs:
 
           ## Diff
           echo "## Diff" >> notes.txt
-          echo "${ORIGINAL_RN}" | grep "\*\*Full Changelog\*\*" >> notes.txt
+          echo "${ORIGINAL_RN}" | grep "\*\*Full Changelog\*\*" >> notes.txt || true
 
           # set new release notes
           gh release edit "${product_version}" --notes-file notes.txt

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2392,7 +2392,7 @@ jobs:
 
                   filtered_body=$(echo "$pr_body" | \
                   grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" | \
-                    sed '/^[[:space:]]*$/d')
+                    sed '/^[[:space:]]*$/d' || true)
 
                   # Only add if there's content left after filtering
                   if [ -n "$filtered_body" ]; then
@@ -2408,7 +2408,7 @@ jobs:
               echo "No PRs." >> notes.txt
           else
               pr_list=$(echo "${ORIGINAL_RN}" | grep "\* .* by @.* in https://github.com/${{ github.repository_owner }}/" | \
-                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+                grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
               if [ -n "$pr_list" ]; then
                 echo "$pr_list" >> notes.txt
@@ -2420,7 +2420,7 @@ jobs:
 
           ## Diff
           echo "## Diff" >> notes.txt
-          echo "${ORIGINAL_RN}" | grep "\*\*Full Changelog\*\*" >> notes.txt
+          echo "${ORIGINAL_RN}" | grep "\*\*Full Changelog\*\*" >> notes.txt || true
 
           # set new release notes
           gh release edit "${product_version}" --notes-file notes.txt

--- a/.github/workflows/py-workflow.yml
+++ b/.github/workflows/py-workflow.yml
@@ -557,14 +557,17 @@ jobs:
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
-        # If filtering removed everything or resulted in empty content, keep original
-        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
-          echo "No content left after filtering, keeping original release notes"
+        # Keep only non-empty lines for emptiness checks
+        non_empty_filtered=$(echo "$filtered_notes" | sed '/^[[:space:]]*$/d')
+
+        if [ -z "$non_empty_filtered" ]; then
+          echo "No relevant changes." > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         else
           # Update the release with filtered notes
-          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          echo "$non_empty_filtered" > /tmp/filtered_notes.txt
           gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         fi
       env:

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -619,14 +619,17 @@ jobs:
         current_notes=$(gh release view "$product_version" --json body --jq .body)
 
         filtered_notes=$(echo "$current_notes" | \
-          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+          grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
-        # If filtering removed everything or resulted in empty content, keep original
-        if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
-          echo "No content left after filtering, keeping original release notes"
+        # Keep only non-empty lines for emptiness checks
+        non_empty_filtered=$(echo "$filtered_notes" | sed '/^[[:space:]]*$/d')
+
+        if [ -z "$non_empty_filtered" ]; then
+          echo "No relevant changes." > /tmp/filtered_notes.txt
+          gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         else
           # Update the release with filtered notes
-          echo "$filtered_notes" > /tmp/filtered_notes.txt
+          echo "$non_empty_filtered" > /tmp/filtered_notes.txt
           gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
         fi
       env:

--- a/.github/workflows/service-py-deb-workflow.yml
+++ b/.github/workflows/service-py-deb-workflow.yml
@@ -812,14 +812,17 @@ jobs:
           current_notes=$(gh release view "$product_version" --json body --jq .body)
 
           filtered_notes=$(echo "$current_notes" | \
-            grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection")
+            grep -v -E -i "Temporary PR:|Temporary PR to bypass branch protection" || true)
 
-          # If filtering removed everything or resulted in empty content, keep original
-          if [ -z "$(echo "$filtered_notes" | grep -v '^[[:space:]]*$')" ]; then
-            echo "No content left after filtering, keeping original release notes"
+          # Keep only non-empty lines for emptiness checks
+          non_empty_filtered=$(echo "$filtered_notes" | sed '/^[[:space:]]*$/d')
+
+          if [ -z "$non_empty_filtered" ]; then
+            echo "No relevant changes." > /tmp/filtered_notes.txt
+            gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
           else
             # Update the release with filtered notes
-            echo "$filtered_notes" > /tmp/filtered_notes.txt
+            echo "$non_empty_filtered" > /tmp/filtered_notes.txt
             gh release edit "$product_version" --notes-file /tmp/filtered_notes.txt
           fi
         env:


### PR DESCRIPTION
Problem:
- When generating release notes, if a PR contained only temporary bypass messages (like "Temporary PR to bypass branch protection"), filtering that content left nothing. Under bash's -e/pipefail mode, grep returns exit code 1 when no lines match, which caused the entire step to fail and prevented processing of remaining PRs.

Solution:

- Added || true to all grep filtering commands so they never fail on no-match
   - In integration-build-product.yml: Loop now continues through all PRs, correctly including automation/substantive PRs even after filtering temporary ones
   - In frontend-monorepo-workflow.yml: Added same fix + changed empty-after-filter behavior to set a default "No relevant changes." message instead of keeping unfiltered content
   
   
Fixing: https://github.com/MOV-AI/project-movai-studio/actions/runs/26754209893


