### PR TITLE
DP-2126: Update npm-buildserver image version to 1.1.1 in workflow

### DIFF
--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -93,7 +93,7 @@ jobs:
     if: ${{ inputs.release == 'false' }}
     runs-on: ubuntu-22.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:v1.0.0
+      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:  [Build]
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:v1.0.0
+      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
       options: --user root
       credentials:
         username: ${{secrets.registry_user}}
@@ -497,7 +497,7 @@ jobs:
     if: ${{ inputs.release == 'true' }}
     runs-on: ubuntu-22.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:v1.0.0
+      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}

--- a/.github/workflows/frontend-monorepo-workflow.yml
+++ b/.github/workflows/frontend-monorepo-workflow.yml
@@ -93,7 +93,7 @@ jobs:
     if: ${{ inputs.release == 'false' }}
     runs-on: ubuntu-22.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
+      image: registry.cloud.mov.ai/qa/npm-buildserver:1.1.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:  [Build]
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
+      image: registry.cloud.mov.ai/qa/npm-buildserver:1.1.1
       options: --user root
       credentials:
         username: ${{secrets.registry_user}}
@@ -497,7 +497,7 @@ jobs:
     if: ${{ inputs.release == 'true' }}
     runs-on: ubuntu-22.04
     container:
-      image: registry.aws.cloud.mov.ai/qa/npm-buildserver:1.1.1
+      image: registry.cloud.mov.ai/qa/npm-buildserver:1.1.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}


### PR DESCRIPTION
This pull request updates the container image version used in several jobs within the `.github/workflows/frontend-monorepo-workflow.yml` file. The main change is upgrading the `npm-buildserver` image from version `v1.0.0` to `1.1.1` to ensure the workflow uses the latest build environment

Related to: https://github.com/MOV-AI/ci-agent-docker-npm-build-server/pull/3 & https://github.com/MOV-AI/.github/pull/556