### PR TITLE
chore: update CI_INTEGRATION_SCRIPTS_VERSION to 4.1.0.3 in workflow files

### DIFF
--- a/.github/workflows/infra-recreation.yml
+++ b/.github/workflows/infra-recreation.yml
@@ -40,7 +40,7 @@ on:
         required: true
 
 env:
-  CI_INTEGRATION_SCRIPTS_VERSION: "4.0.0.31"
+  CI_INTEGRATION_SCRIPTS_VERSION: "4.1.0.3"
   PROVISION_INFRA_REPO: "devops-tf-bpg-runners"
   PROVISION_INFRA_VERSION: "0.1.0-2"
   PROVISION_ENV_CONF_REPO: "devops-tf-env-conf"

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -125,7 +125,7 @@ on:
       fleet_password:
         required: true
 env:
-  CI_INTEGRATION_SCRIPTS_VERSION: "4.0.2.3"
+  CI_INTEGRATION_SCRIPTS_VERSION: "4.1.0.3"
   MOBTEST_VERSION: "0.0.7.2"
   PACKAGE_DEPLOYER_VERSION: "1.0.0.40"
   GITHUB_API_USR: "OttoMation-Movai"


### PR DESCRIPTION
update CI_INTEGRATION_SCRIPTS_VERSION to 4.1.0.3 in workflow files

impacted pipeline:
- infra_recreation
- EE