### PR TITLE
chore: update provisioning versions to 2.2.0-1 and 0.2.2-4

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -149,7 +149,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.0.0-17"
+  PROVISION_INFRA_VERSION: "2.2.0-1"
   DEVOPS_SLACK_CHANNEL: "G0102LEV1CL"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}
@@ -159,7 +159,7 @@ env:
   MINIO_S3_URL: "https://s3.mov.ai"
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   TIMEOUT: 720
-  PROVISIONING_ENV_CONF: "0.2.0-8"
+  PROVISIONING_ENV_CONF: "0.2.2-4"
 
 jobs:
   Compute-timeout:


### PR DESCRIPTION
This pull request updates two environment variables in the `.github/workflows/integration-build-product.yml` workflow file to use newer versions of infrastructure and configuration dependencies. These updates will ensure the workflow uses the latest features and fixes from these dependencies.

Dependency version updates:

* Updated `PROVISION_INFRA_VERSION` to `2.2.0-1` to use the latest version of the infrastructure provisioning repository.
* Updated `PROVISIONING_ENV_CONF` to `0.2.2-4` for the latest provisioning environment configuration.

test on tugbot: https://github.com/MOV-AI/project-tugbot2/actions/runs/27773569194

test on studio: https://github.com/MOV-AI/project-movai-studio/actions/runs/27773101102