### PR TITLE
DP-2134: Fix failures in runner recreation pipeline - Provision self-hosted infrastructure

### DIFF
--- a/.github/workflows/infra-recreation.yml
+++ b/.github/workflows/infra-recreation.yml
@@ -1668,7 +1668,7 @@ jobs:
             }
 
       - name: Send Slack Message
-        if: ${{ always() && (! needs.Provision-IP-Runners.result == 'success' || ! needs.Provision-QA-Runners.result == 'success' || ! needs.Provision-Robotics-Sim-Runners.result == 'success' || ! needs.Provision-Redhat-Oracle-Runners.result == 'success' || ! needs.Provision-Packer-Runners.result == 'success') }}
+        if: ${{ always() && (needs.Provision-IP-Runners.result != 'success' || needs.Provision-QA-Runners.result != 'success' || needs.Provision-Robotics-Sim-Runners.result != 'success' || needs.Provision-Redhat-Oracle-Runners.result != 'success' || needs.Provision-Packer-Runners.result != 'success') }}
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.update


### PR DESCRIPTION
Proxmox provisioning can intermittently fail with HTTP 596: Broken pipe, but those failures were previously not being reported to Slack due to workflow condition handling.

**Changes**: Fixed workflow logic so Slack failure alert is correctly triggered.

**TODO**: Reduce Proxmox provisioning parallelism (e.g. parallelism=1) to mitigate transient VM creation issues.