### PR TITLE
DP-2096 - Feat/docker SBOM cyclone dx

### DIFF
--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -5,6 +5,10 @@ inputs:
   image:
     description: Fully qualified image reference with tag
     required: true
+  digest:
+    description: Image digest (sha256:...) for exact pushed reference; if omitted, digest is resolved from image
+    required: false
+    default: ""
   sbom_file:
     description: Output file for generated CycloneDX JSON
     required: false
@@ -21,10 +25,38 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve image subject reference
+      id: resolve_subject
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        DIGEST_INPUT: ${{ inputs.digest }}
+      run: |
+        set -e -o pipefail
+
+        DIGEST="${DIGEST_INPUT}"
+        if [ -z "${DIGEST}" ] && [[ "${IMAGE}" == *@sha256:* ]]; then
+          DIGEST="${IMAGE##*@}"
+        fi
+        if [ -z "${DIGEST}" ]; then
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE}" | awk '/Digest:/ { print $2; exit }')"
+        fi
+
+        if [ -z "${DIGEST}" ]; then
+          echo "Failed to resolve digest for ${IMAGE}"
+          exit 1
+        fi
+
+        SUBJECT_REF="${IMAGE%@*}@${DIGEST}"
+        echo "Using subject reference: ${SUBJECT_REF}"
+
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        echo "subject_ref=${SUBJECT_REF}" >> "$GITHUB_OUTPUT"
+
     - name: Generate CycloneDX SBOM
       uses: anchore/sbom-action@v0
       with:
-        image: ${{ inputs.image }}
+        image: ${{ steps.resolve_subject.outputs.subject_ref }}
         format: cyclonedx-json
         output-file: ${{ inputs.sbom_file }}
 
@@ -36,18 +68,11 @@ runs:
     - name: Attach CycloneDX SBOM as Harbor accessory
       shell: bash
       env:
-        IMAGE: ${{ inputs.image }}
+        SUBJECT_REF: ${{ steps.resolve_subject.outputs.subject_ref }}
         SBOM_FILE: ${{ inputs.sbom_file }}
       run: |
         set -e -o pipefail
 
-        DIGEST="$(docker buildx imagetools inspect "${IMAGE}" | awk '/Digest:/ { print $2; exit }')"
-        if [ -z "${DIGEST}" ]; then
-          echo "Failed to resolve digest for ${IMAGE}"
-          exit 1
-        fi
-
-        SUBJECT_REF="${IMAGE%@*}@${DIGEST}"
         echo "Attaching SBOM to subject: ${SUBJECT_REF}"
 
         oras attach \

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -1,0 +1,64 @@
+name: Attach CycloneDX SBOM
+description: Generate CycloneDX SBOM for a pushed image and attach it as OCI accessory using ORAS
+
+inputs:
+  image:
+    description: Fully qualified image reference with tag
+    required: true
+  sbom_file:
+    description: Output file for generated CycloneDX JSON
+    required: false
+    default: sbom.cyclonedx.json
+  artifact_name:
+    description: GitHub artifact name used for the SBOM file
+    required: false
+    default: sbom
+  upload_artifact:
+    description: Upload SBOM as GitHub artifact
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Generate CycloneDX SBOM
+      uses: anchore/sbom-action@v0
+      with:
+        image: ${{ inputs.image }}
+        format: cyclonedx-json
+        output-file: ${{ inputs.sbom_file }}
+
+    - name: Set up ORAS
+      uses: oras-project/setup-oras@v2
+
+    - name: Attach CycloneDX SBOM as Harbor accessory
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        SBOM_FILE: ${{ inputs.sbom_file }}
+      run: |
+        set -e -o pipefail
+
+        DIGEST="$(docker buildx imagetools inspect "${IMAGE}" | awk '/Digest:/ { print $2; exit }')"
+        if [ -z "${DIGEST}" ]; then
+          echo "Failed to resolve digest for ${IMAGE}"
+          exit 1
+        fi
+
+        SUBJECT_REF="${IMAGE%@*}@${DIGEST}"
+        echo "Attaching SBOM to subject: ${SUBJECT_REF}"
+
+        oras attach \
+          --artifact-type "sbom/cyclonedx" \
+          --annotation "org.opencontainers.artifact.description=CycloneDX SBOM" \
+          "${SUBJECT_REF}" \
+          "${SBOM_FILE}:application/vnd.cyclonedx+json"
+
+        echo "CycloneDX SBOM attached as Harbor accessory"
+
+    - name: Upload CycloneDX SBOM as GitHub artifact
+      if: ${{ inputs.upload_artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.sbom_file }}

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -62,8 +62,6 @@ runs:
 
     - name: Set up ORAS
       uses: oras-project/setup-oras@v2
-      with:
-        version: 1.3.2
 
     - name: Attach CycloneDX SBOM as Harbor accessory
       shell: bash

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -30,6 +30,8 @@ runs:
 
     - name: Set up ORAS
       uses: oras-project/setup-oras@v2
+      with:
+        version: 1.3.2
 
     - name: Attach CycloneDX SBOM as Harbor accessory
       shell: bash

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - name: Upload CycloneDX SBOM as GitHub artifact
       if: ${{ inputs.upload_artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.sbom_file }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -92,6 +92,11 @@ on:
         type: boolean
         default: false
         description: boolean to create GitHub Release with build metadata and digests (requires commit_token secret)
+      generate_sbom:
+        required: false
+        type: boolean
+        default: true
+        description: boolean to generate CycloneDX SBOM and attach it as Harbor accessory
     secrets:
       registry_user:
         required: true
@@ -454,6 +459,7 @@ jobs:
           registry: ${{ inputs.github_registry }}
 
       - name: Distribute images to official and public registries
+        id: push_images
         env:
           VERSION: ${{ needs.raise-version.outputs.package_version }}
           LATEST: ${{ inputs.push_latest }}
@@ -466,6 +472,8 @@ jobs:
           # Extract image directory and name
           OFC_IMAGE_DIR="${DOCKER_IMAGE%%/*}"
           OFC_IMAGE_NAME="${DOCKER_IMAGE#*/}"
+          OFFICIAL_IMAGE="${DOCKER_REGISTRY}/${OFC_IMAGE_DIR}/${OFC_IMAGE_NAME}:${VERSION}"
+          echo "image=${OFFICIAL_IMAGE}" | tee -a "$GITHUB_OUTPUT"
 
           # Pull from CI directory
           echo "Pulling image from CI registry..."
@@ -475,8 +483,8 @@ jobs:
           # Push to official directory with version tag
           echo "Pushing to official registry with version tag..."
           docker tag "${DOCKER_REGISTRY}/ci/${OFC_IMAGE_NAME}:${VERSION}" \
-                     "${DOCKER_REGISTRY}/${OFC_IMAGE_DIR}/${OFC_IMAGE_NAME}:${VERSION}"
-          docker push "${DOCKER_REGISTRY}/${OFC_IMAGE_DIR}/${OFC_IMAGE_NAME}:${VERSION}"
+                     "${OFFICIAL_IMAGE}"
+          docker push "${OFFICIAL_IMAGE}"
           echo "✓ Successfully pushed version tag to official registry"
 
           # Handle latest tag
@@ -524,6 +532,13 @@ jobs:
 
           echo "✓ Image distribution completed successfully"
 
+      - name: Generate and attach CycloneDX SBOM
+        if: ${{ inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        with:
+          image: ${{ steps.push_images.outputs.image }}
+          artifact_name: sbom
+
       - name: Install bump-my-version for pushing version changes
         if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
         run: python3 -m pip install bump-my-version
@@ -560,6 +575,12 @@ jobs:
         with:
           name: release-notes
 
+      - name: Download CycloneDX SBOM artifact
+        if: ${{ inputs.generate_sbom }}
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom
+
       - name: Replace version placeholder and append metadata
         env:
           VERSION: ${{ needs.raise-version.outputs.package_version }}
@@ -592,3 +613,11 @@ jobs:
           draft: false
           prerelease: true
           token: ${{ secrets.commit_token }}
+
+      - name: Upload CycloneDX SBOM to GitHub Release
+        if: ${{ inputs.generate_sbom }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.raise-version.outputs.package_version }}
+          name: Release v${{ needs.raise-version.outputs.package_version }}
+          files: sbom.cyclonedx.json

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -354,6 +354,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build image and push to /ci/
+        id: build_ci_image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -370,11 +371,19 @@ jobs:
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
 
+      - name: Re-login to Private Registry before CI SBOM
+        if: ${{ inputs.generate_sbom }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.registry_user }}
+          password: ${{ secrets.registry_password }}
+          registry: ${{ inputs.docker_registry }}
+
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
-          image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          image: ${{ format('{0}@{1}', steps.get_image_names.outputs.DOCKER_IMAGES, steps.build_ci_image.outputs.digest) }}
           sbom_file: sbom-ci-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-ci-${{ matrix.name }}
   test:
@@ -490,7 +499,14 @@ jobs:
           echo "Pushing to official registry with version tag..."
           docker tag "${DOCKER_REGISTRY}/ci/${OFC_IMAGE_NAME}:${VERSION}" \
                      "${OFFICIAL_IMAGE}"
-          docker push "${OFFICIAL_IMAGE}"
+          OFFICIAL_PUSH_OUTPUT="$(docker push "${OFFICIAL_IMAGE}" 2>&1)"
+          echo "${OFFICIAL_PUSH_OUTPUT}"
+          OFFICIAL_DIGEST="$(printf '%s\n' "${OFFICIAL_PUSH_OUTPUT}" | awk '/digest: sha256:/ { print $2; exit }')"
+          if [ -z "${OFFICIAL_DIGEST}" ]; then
+            echo "Failed to capture digest for pushed image ${OFFICIAL_IMAGE}"
+            exit 1
+          fi
+          echo "digest=${OFFICIAL_DIGEST}" | tee -a "$GITHUB_OUTPUT"
           echo "✓ Successfully pushed version tag to official registry"
 
           # Handle latest tag
@@ -542,7 +558,7 @@ jobs:
         if: ${{ inputs.generate_sbom }}
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
-          image: ${{ steps.push_images.outputs.image }}
+          image: ${{ format('{0}@{1}', steps.push_images.outputs.image, steps.push_images.outputs.digest) }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-official-${{ matrix.name }}
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -381,7 +381,7 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
         with:
           image: ${{ format('{0}@{1}', steps.get_image_names.outputs.DOCKER_IMAGES, steps.build_ci_image.outputs.digest) }}
           sbom_file: sbom-ci-${{ matrix.name }}.cyclonedx.json
@@ -556,7 +556,7 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
         with:
           image: ${{ format('{0}@{1}', steps.push_images.outputs.image, steps.push_images.outputs.digest) }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Upload release notes template
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes
           path: release_notes_template.md
@@ -369,7 +369,6 @@ jobs:
           target: ${{ matrix.target }}
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
-          secrets: ${{ steps.get_secret_args.outputs.build_secrets_args_str_list }}
 
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
@@ -546,6 +545,7 @@ jobs:
           image: ${{ steps.push_images.outputs.image }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-official-${{ matrix.name }}
+
       - name: Install bump-my-version for pushing version changes
         if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
         run: python3 -m pip install bump-my-version
@@ -588,6 +588,7 @@ jobs:
         with:
           pattern: sbom-*
           merge-multiple: true
+
       - name: Replace version placeholder and append metadata
         env:
           VERSION: ${{ needs.raise-version.outputs.package_version }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -376,8 +376,8 @@ jobs:
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
           image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
-          artifact_name: sbom
-
+          sbom_file: sbom-ci-${{ matrix.name }}.cyclonedx.json
+          artifact_name: sbom-ci-${{ matrix.name }}
   test:
     needs: [raise-version, build, parse-matrix]
     if: ${{ inputs.deploy && needs.build.result == 'success' }}
@@ -544,8 +544,8 @@ jobs:
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
           image: ${{ steps.push_images.outputs.image }}
-          artifact_name: sbom
-
+          sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
+          artifact_name: sbom-official-${{ matrix.name }}
       - name: Install bump-my-version for pushing version changes
         if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
         run: python3 -m pip install bump-my-version
@@ -582,12 +582,12 @@ jobs:
         with:
           name: release-notes
 
-      - name: Download CycloneDX SBOM artifact
+      - name: Download CycloneDX SBOM artifacts
         if: ${{ inputs.generate_sbom }}
         uses: actions/download-artifact@v4
         with:
-          name: sbom
-
+          pattern: sbom-*
+          merge-multiple: true
       - name: Replace version placeholder and append metadata
         env:
           VERSION: ${{ needs.raise-version.outputs.package_version }}
@@ -621,10 +621,10 @@ jobs:
           prerelease: true
           token: ${{ secrets.commit_token }}
 
-      - name: Upload CycloneDX SBOM to GitHub Release
+      - name: Upload CycloneDX SBOMs to GitHub Release
         if: ${{ inputs.generate_sbom }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.raise-version.outputs.package_version }}
-          name: Release v${{ needs.raise-version.outputs.package_version }}
-          files: sbom.cyclonedx.json
+          files: sbom-*.cyclonedx.json
+          token: ${{ secrets.commit_token }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -371,6 +371,13 @@ jobs:
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
           secrets: ${{ steps.get_secret_args.outputs.build_secrets_args_str_list }}
 
+      - name: Generate and attach CycloneDX SBOM to /ci/ image
+        if: ${{ inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        with:
+          image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          artifact_name: sbom
+
   test:
     needs: [raise-version, build, parse-matrix]
     if: ${{ inputs.deploy && needs.build.result == 'success' }}

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -56,11 +56,6 @@ on:
         type: boolean
         default: true
         description: Flag to enable/disable the Robotic Stack Integration tests
-      generate_sbom:
-        required: false
-        type: boolean
-        default: true
-        description: Generate CycloneDX SBOM and attach it as Harbor accessory for pushed images
       provision_tf_env_repo:
         required: false
         type: string
@@ -591,13 +586,6 @@ jobs:
             BASE_IMAGE=${{ steps.pre_build.outputs.base_name }}
             CI_SCRIPT_VERSION=${{ env.CI_INTEGRATION_SCRIPTS_VERSION }}
 
-      - name: Generate and attach simulator CycloneDX SBOM
-        if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' && inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
-        with:
-          image: ${{ env.REGISTRY }}/qa/${{ steps.pre_build.outputs.image_name }}
-          artifact_name: sbom-simulator
-
       - name: Collect Installed components
         if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
         shell: bash
@@ -820,13 +808,6 @@ jobs:
           git commit -m "[skip actions] Automatic Raise"
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
-
-      - name: Generate and attach backend CycloneDX SBOM
-        if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
-        with:
-          image: ${{ env.PUSH_REGISTRY }}/qa/${{ needs.Validations-Finish.outputs.backend_image }}
-          artifact_name: sbom-backend
 
       - name: Prepare raise variables
         id: pre_raise

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -56,6 +56,11 @@ on:
         type: boolean
         default: true
         description: Flag to enable/disable the Robotic Stack Integration tests
+      generate_sbom:
+        required: false
+        type: boolean
+        default: true
+        description: Generate CycloneDX SBOM and attach it as Harbor accessory for pushed images
       provision_tf_env_repo:
         required: false
         type: string
@@ -586,6 +591,13 @@ jobs:
             BASE_IMAGE=${{ steps.pre_build.outputs.base_name }}
             CI_SCRIPT_VERSION=${{ env.CI_INTEGRATION_SCRIPTS_VERSION }}
 
+      - name: Generate and attach simulator CycloneDX SBOM
+        if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' && inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        with:
+          image: ${{ env.REGISTRY }}/qa/${{ steps.pre_build.outputs.image_name }}
+          artifact_name: sbom-simulator
+
       - name: Collect Installed components
         if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
         shell: bash
@@ -808,6 +820,13 @@ jobs:
           git commit -m "[skip actions] Automatic Raise"
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
+
+      - name: Generate and attach backend CycloneDX SBOM
+        if: ${{ inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        with:
+          image: ${{ env.PUSH_REGISTRY }}/qa/${{ needs.Validations-Finish.outputs.backend_image }}
+          artifact_name: sbom-backend
 
       - name: Prepare raise variables
         id: pre_raise


### PR DESCRIPTION
This pull request introduces automated generation and attachment of CycloneDX SBOMs (Software Bill of Materials) for Docker images in both the main Docker workflow and the integration build platform workflow. The SBOMs are generated after image builds and are attached as OCI accessories using ORAS, uploaded as GitHub artifacts, and optionally included in GitHub Releases. This enhances supply chain security and compliance by providing detailed component inventories for built images.

**CycloneDX SBOM Integration**

* Added a new reusable composite action, `attach-cyclonedx-sbom`, which generates a CycloneDX SBOM for a given image, attaches it as an OCI accessory using ORAS, and optionally uploads it as a GitHub artifact (`.github/actions/attach-cyclonedx-sbom/action.yml`).

**Workflow Enhancements: Docker Workflow**

* Introduced a `generate_sbom` input (default: true) to control SBOM generation in `.github/workflows/docker-workflow.yml`.
* After building and distributing images, the workflow now generates and attaches CycloneDX SBOMs to both `/ci/` and official images, uploads them as artifacts, and includes them in GitHub Releases if enabled [[1]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR374-R380) [[2]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR542-R548) [[3]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR585-R590) [[4]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR623-R630).
* Refactored image tagging to use a new `OFFICIAL_IMAGE` variable for clarity and reuse [[1]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR469) [[2]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bR482-R483) [[3]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bL478-R494).

**Workflow Enhancements: Integration Build Platform**

* Added a `generate_sbom` input (default: true) to control SBOM generation in `.github/workflows/integration-build-platform.yml`.
* After simulator and backend image builds, the workflow now generates and attaches CycloneDX SBOMs as OCI accessories and uploads them as artifacts [[1]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535R594-R600) [[2]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535R824-R830).

These changes automate SBOM generation and attachment for all built images, improving traceability and compliance in the CI/CD pipeline.