### PR TITLE
use python3.10 for ci-venv

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -1407,20 +1407,20 @@ jobs:
           echo "public ip: $(curl ipinfo.io/ip)"
           echo "private ip: $(hostname -I | awk '{print $1}')"
 
-      - name: Setup python3.9
+      - name: Setup python3.10
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Setup CI Scripts in .ci-venv
         shell: bash
         run: |
-          python3.9 -m venv .ci-venv --clear
+          python3.10 -m venv .ci-venv --clear
           . .ci-venv/bin/activate
-          [ -f ci-requirements.txt ] && python3.9 -m pip install -r ci-requirements.txt
-          python3.9 -m pip install --upgrade pyOpenSSL cryptography
+          [ -f ci-requirements.txt ] && python3 -m pip install -r ci-requirements.txt
+          python3 -m pip install --upgrade pyOpenSSL cryptography
           extra_args="-i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple"
-          python3.9 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed $extra_args
+          python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed $extra_args
 
       - name: Check AWS Cli
         shell: bash


### PR DESCRIPTION
This pull request updates the Python version used in the integration build workflow from 3.9 to 3.10. The changes ensure that all Python-related setup and commands now reference Python 3.10, aligning the CI environment with a more current Python version.

CI environment update:

* Updated the GitHub Actions workflow (`.github/workflows/integration-build-product.yml`) to use Python 3.10 instead of 3.9 for setting up the environment, creating the virtual environment, and running pip commands.

Tested OK after installing : `uv python install 3.10`