### PR TITLE
DP-2096 - Feat/docker SBOM cyclone dx

### DIFF
--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -6,9 +6,8 @@ inputs:
     description: Fully qualified image reference with tag
     required: true
   digest:
-    description: Image digest (sha256:...) for exact pushed reference; if omitted, digest is resolved from image
-    required: false
-    default: ""
+    description: Image digest (sha256:...) for exact pushed reference
+    required: true
   sbom_file:
     description: Output file for generated CycloneDX JSON
     required: false
@@ -25,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Resolve image subject reference
+    - name: Build exact image subject reference
       id: resolve_subject
       shell: bash
       env:
@@ -34,23 +33,17 @@ runs:
       run: |
         set -e -o pipefail
 
-        DIGEST="${DIGEST_INPUT}"
-        if [ -z "${DIGEST}" ] && [[ "${IMAGE}" == *@sha256:* ]]; then
-          DIGEST="${IMAGE##*@}"
-        fi
-        if [ -z "${DIGEST}" ]; then
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}" | awk '/Digest:/ { print $2; exit }')"
-        fi
+        DIGEST="${DIGEST_INPUT#digest:}"
+        DIGEST="${DIGEST#:}"
 
-        if [ -z "${DIGEST}" ]; then
-          echo "Failed to resolve digest for ${IMAGE}"
+        if ! [[ "${DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+          echo "Invalid digest provided: ${DIGEST_INPUT}"
           exit 1
         fi
 
-        SUBJECT_REF="${IMAGE%@*}@${DIGEST}"
+        IMAGE_BASE="${IMAGE%@*}"
+        SUBJECT_REF="${IMAGE_BASE}@${DIGEST}"
         echo "Using subject reference: ${SUBJECT_REF}"
-
-        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         echo "subject_ref=${SUBJECT_REF}" >> "$GITHUB_OUTPUT"
 
     - name: Generate CycloneDX SBOM

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -32,9 +32,9 @@ runs:
         DIGEST_INPUT: ${{ inputs.digest }}
       run: |
         set -e -o pipefail
-
         DIGEST="${DIGEST_INPUT}"
-
+        DIGEST="${DIGEST//[[:space:]]/}"
+        DIGEST="${DIGEST,,}"
         if ! [[ "${DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
           echo "Invalid digest format (expected sha256:<64-hex>): ${DIGEST_INPUT}"
           exit 1

--- a/.github/actions/attach-cyclonedx-sbom/action.yml
+++ b/.github/actions/attach-cyclonedx-sbom/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Fully qualified image reference with tag
     required: true
   digest:
-    description: Image digest (sha256:...) for exact pushed reference
+    description: Image digest in canonical format sha256:<64-hex>
     required: true
   sbom_file:
     description: Output file for generated CycloneDX JSON
@@ -33,11 +33,10 @@ runs:
       run: |
         set -e -o pipefail
 
-        DIGEST="${DIGEST_INPUT#digest:}"
-        DIGEST="${DIGEST#:}"
+        DIGEST="${DIGEST_INPUT}"
 
         if ! [[ "${DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-          echo "Invalid digest provided: ${DIGEST_INPUT}"
+          echo "Invalid digest format (expected sha256:<64-hex>): ${DIGEST_INPUT}"
           exit 1
         fi
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -503,8 +503,6 @@ jobs:
           OFFICIAL_PUSH_OUTPUT="$(docker push "${OFFICIAL_IMAGE}" 2>&1)"
           echo "${OFFICIAL_PUSH_OUTPUT}"
           OFFICIAL_DIGEST="$(printf '%s\n' "${OFFICIAL_PUSH_OUTPUT}" | awk '/digest: sha256:/ { print $2; exit }')"
-          OFFICIAL_DIGEST="${OFFICIAL_DIGEST#digest:}"
-          OFFICIAL_DIGEST="${OFFICIAL_DIGEST#:}"
 
           if [ -z "${OFFICIAL_DIGEST}" ] || ! [[ "${OFFICIAL_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
             echo "Failed to capture digest for pushed image ${OFFICIAL_IMAGE}"
@@ -515,32 +513,6 @@ jobs:
 
           # Handle latest tag
           if [ "${LATEST}" = "true" ]; then
-
-      - name: Prepare official SBOM image ref
-        id: prepare_official_sbom_image
-        if: ${{ inputs.generate_sbom }}
-        shell: bash
-        env:
-          IMAGE_BASE: ${{ steps.push_images.outputs.image }}
-          DIGEST_INPUT: ${{ steps.push_images.outputs.digest }}
-        run: |
-          set -e -o pipefail
-
-          DIGEST="${DIGEST_INPUT#digest:}"
-          DIGEST="${DIGEST#:}"
-
-          if [ -n "${DIGEST}" ] && ! [[ "${DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-            echo "Invalid official digest: ${DIGEST}"
-            exit 1
-          fi
-
-          if [ -n "${DIGEST}" ]; then
-            IMAGE_REF="${IMAGE_BASE}@${DIGEST}"
-          else
-            IMAGE_REF="${IMAGE_BASE}"
-          fi
-
-          echo "image=${IMAGE_REF}" | tee -a "$GITHUB_OUTPUT"
             echo "Pushing latest tag to official registry..."
             docker tag "${DOCKER_REGISTRY}/ci/${OFC_IMAGE_NAME}:${VERSION}" \
                        "${DOCKER_REGISTRY}/${OFC_IMAGE_DIR}/${OFC_IMAGE_NAME}:latest"
@@ -588,7 +560,7 @@ jobs:
         if: ${{ inputs.generate_sbom }}
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
-          image: ${{ steps.prepare_official_sbom_image.outputs.image }}
+          image: ${{ steps.push_images.outputs.image }}
           digest: ${{ steps.push_images.outputs.digest }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-official-${{ matrix.name }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -381,7 +381,7 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX_reviewed
         with:
           image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           digest: ${{ steps.build_ci_image.outputs.digest }}
@@ -558,7 +558,7 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX_reviewed
         with:
           image: ${{ steps.push_images.outputs.image }}
           digest: ${{ steps.push_images.outputs.digest }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -381,7 +381,7 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
-        uses: ./.github/actions/attach-cyclonedx-sbom
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
           image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
           digest: ${{ steps.build_ci_image.outputs.digest }}
@@ -586,9 +586,10 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX
         with:
           image: ${{ steps.prepare_official_sbom_image.outputs.image }}
+          digest: ${{ steps.push_images.outputs.digest }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-official-${{ matrix.name }}
 
@@ -604,10 +605,9 @@ jobs:
 
       - name: Download CycloneDX SBOM artifacts
         if: ${{ inputs.generate_sbom }}
-        uses: ./.github/actions/attach-cyclonedx-sbom
+        uses: actions/download-artifact@v4
         with:
-          image: ${{ steps.push_images.outputs.image }}
-          digest: ${{ steps.push_images.outputs.digest }}
+          pattern: sbom-*
           merge-multiple: true
 
       - name: Replace version placeholder and append metadata

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -137,10 +137,10 @@ jobs:
       GITHUB_REGISTRY: ${{ inputs.github_registry }}
     steps:
       - name: Checkout calling repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Checkout workflow repository for scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: MOV-AI/.github
           path: .github-workflows
@@ -190,7 +190,7 @@ jobs:
       matrix: ${{ fromJSON(needs.parse-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Hadolint ${{ matrix.docker_file }}
         uses: hadolint/hadolint-action@v3.3.0
@@ -207,7 +207,7 @@ jobs:
       branch_name: ${{ steps.branch.outputs.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Use manual version
         if: ${{ inputs.version != 'auto' }}
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Login to Private Registry
         uses: docker/login-action@v3
@@ -341,7 +341,7 @@ jobs:
 
       - name: Download packages to include in build
         if: ${{ matrix.download_artifact}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.download_artifact_name }}
           path: ${{ matrix.download_artifact_path }}
@@ -371,14 +371,6 @@ jobs:
           pull: true
           build-args: ${{ steps.get_build_args.outputs.build_args_str_list }}
 
-      - name: Re-login to Private Registry before CI SBOM
-        if: ${{ inputs.generate_sbom }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.registry_user }}
-          password: ${{ secrets.registry_password }}
-          registry: ${{ inputs.docker_registry }}
-
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@feat/docker_sbom_cycloneDX_reviewed
@@ -387,6 +379,7 @@ jobs:
           digest: ${{ steps.build_ci_image.outputs.digest }}
           sbom_file: sbom-ci-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-ci-${{ matrix.name }}
+
   test:
     needs: [raise-version, build, parse-matrix]
     if: ${{ inputs.deploy && needs.build.result == 'success' }}
@@ -398,7 +391,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Login to Private Registry
         uses: docker/login-action@v3
@@ -449,7 +442,7 @@ jobs:
       GITHUB_REGISTRY: ${{ inputs.github_registry }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Login to Private Registry (for push permission)
         uses: docker/login-action@v3
@@ -573,10 +566,36 @@ jobs:
         run: |
           set -e
           git config --global --add safe.directory "$(pwd)"
+          git config --global user.name "${{ secrets.commit_user }}"
+          git config --global user.email "${{ secrets.commit_mail }}"
+          bump-my-version bump patch --commit --tag
+
+      - name: Push version bump to protected branch
+        uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
+        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
+        with:
+          token: ${{ secrets.commit_token }}
+          git_user_email: ${{ secrets.commit_mail }}
+          git_user_name: ${{ secrets.commit_user }}
+          branch: ${{ needs.raise-version.outputs.branch_name }}
+          repository: ${{ github.repository }}
+
+  create-release:
+    needs: [raise-version, publish]
+    if: ${{ inputs.create_release && inputs.deploy }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download release notes
+        uses: actions/download-artifact@v8
+        with:
+          name: release-notes
 
       - name: Download CycloneDX SBOM artifacts
         if: ${{ inputs.generate_sbom }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sbom-*
           merge-multiple: true
@@ -589,7 +608,6 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           set -e
-
           # Replace version placeholder
           sed "s/{{VERSION}}/${VERSION}/g" release_notes_template.md > release_body.md
 

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -502,8 +502,7 @@ jobs:
                      "${OFFICIAL_IMAGE}"
           OFFICIAL_PUSH_OUTPUT="$(docker push "${OFFICIAL_IMAGE}" 2>&1)"
           echo "${OFFICIAL_PUSH_OUTPUT}"
-          OFFICIAL_DIGEST="$(printf '%s\n' "${OFFICIAL_PUSH_OUTPUT}" | awk '/digest: sha256:/ { print $2; exit }')"
-
+          OFFICIAL_DIGEST="$(printf '%s\n' "${OFFICIAL_PUSH_OUTPUT}" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)"
           if [ -z "${OFFICIAL_DIGEST}" ] || ! [[ "${OFFICIAL_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
             echo "Failed to capture digest for pushed image ${OFFICIAL_IMAGE}"
             exit 1

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -381,9 +381,10 @@ jobs:
 
       - name: Generate and attach CycloneDX SBOM to /ci/ image
         if: ${{ inputs.generate_sbom }}
-        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
+        uses: ./.github/actions/attach-cyclonedx-sbom
         with:
-          image: ${{ format('{0}@{1}', steps.get_image_names.outputs.DOCKER_IMAGES, steps.build_ci_image.outputs.digest) }}
+          image: ${{ steps.get_image_names.outputs.DOCKER_IMAGES }}
+          digest: ${{ steps.build_ci_image.outputs.digest }}
           sbom_file: sbom-ci-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-ci-${{ matrix.name }}
   test:
@@ -502,7 +503,10 @@ jobs:
           OFFICIAL_PUSH_OUTPUT="$(docker push "${OFFICIAL_IMAGE}" 2>&1)"
           echo "${OFFICIAL_PUSH_OUTPUT}"
           OFFICIAL_DIGEST="$(printf '%s\n' "${OFFICIAL_PUSH_OUTPUT}" | awk '/digest: sha256:/ { print $2; exit }')"
-          if [ -z "${OFFICIAL_DIGEST}" ]; then
+          OFFICIAL_DIGEST="${OFFICIAL_DIGEST#digest:}"
+          OFFICIAL_DIGEST="${OFFICIAL_DIGEST#:}"
+
+          if [ -z "${OFFICIAL_DIGEST}" ] || ! [[ "${OFFICIAL_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
             echo "Failed to capture digest for pushed image ${OFFICIAL_IMAGE}"
             exit 1
           fi
@@ -511,6 +515,32 @@ jobs:
 
           # Handle latest tag
           if [ "${LATEST}" = "true" ]; then
+
+      - name: Prepare official SBOM image ref
+        id: prepare_official_sbom_image
+        if: ${{ inputs.generate_sbom }}
+        shell: bash
+        env:
+          IMAGE_BASE: ${{ steps.push_images.outputs.image }}
+          DIGEST_INPUT: ${{ steps.push_images.outputs.digest }}
+        run: |
+          set -e -o pipefail
+
+          DIGEST="${DIGEST_INPUT#digest:}"
+          DIGEST="${DIGEST#:}"
+
+          if [ -n "${DIGEST}" ] && ! [[ "${DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Invalid official digest: ${DIGEST}"
+            exit 1
+          fi
+
+          if [ -n "${DIGEST}" ]; then
+            IMAGE_REF="${IMAGE_BASE}@${DIGEST}"
+          else
+            IMAGE_REF="${IMAGE_BASE}"
+          fi
+
+          echo "image=${IMAGE_REF}" | tee -a "$GITHUB_OUTPUT"
             echo "Pushing latest tag to official registry..."
             docker tag "${DOCKER_REGISTRY}/ci/${OFC_IMAGE_NAME}:${VERSION}" \
                        "${DOCKER_REGISTRY}/${OFC_IMAGE_DIR}/${OFC_IMAGE_NAME}:latest"
@@ -558,7 +588,7 @@ jobs:
         if: ${{ inputs.generate_sbom }}
         uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
         with:
-          image: ${{ format('{0}@{1}', steps.push_images.outputs.image, steps.push_images.outputs.digest) }}
+          image: ${{ steps.prepare_official_sbom_image.outputs.image }}
           sbom_file: sbom-official-${{ matrix.name }}.cyclonedx.json
           artifact_name: sbom-official-${{ matrix.name }}
 
@@ -571,38 +601,13 @@ jobs:
         run: |
           set -e
           git config --global --add safe.directory "$(pwd)"
-          git config --global user.name "${{ secrets.commit_user }}"
-          git config --global user.email "${{ secrets.commit_mail }}"
-          bump-my-version bump patch --commit --tag
-
-      - name: Push version bump to protected branch
-        uses: MOV-AI/.github/.github/actions/push-to-protected-branch@v3
-        if: ${{ inputs.version == 'auto' && matrix.name == needs.parse-matrix.outputs.first_image }}
-        with:
-          token: ${{ secrets.commit_token }}
-          git_user_email: ${{ secrets.commit_mail }}
-          git_user_name: ${{ secrets.commit_user }}
-          branch: ${{ needs.raise-version.outputs.branch_name }}
-          repository: ${{ github.repository }}
-
-  create-release:
-    needs: [raise-version, publish]
-    if: ${{ inputs.create_release && inputs.deploy }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Download release notes
-        uses: actions/download-artifact@v4
-        with:
-          name: release-notes
 
       - name: Download CycloneDX SBOM artifacts
         if: ${{ inputs.generate_sbom }}
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/attach-cyclonedx-sbom
         with:
-          pattern: sbom-*
+          image: ${{ steps.push_images.outputs.image }}
+          digest: ${{ steps.push_images.outputs.digest }}
           merge-multiple: true
 
       - name: Replace version placeholder and append metadata


### PR DESCRIPTION
This pull request updates the CycloneDX SBOM attachment process in the Docker workflow to improve digest handling and validation, and to simplify the way image references are managed. The main changes enforce stricter digest input requirements, enhance digest format validation, and update workflow steps to match these improvements.

**SBOM Action Improvements:**

* The `digest` input in `.github/actions/attach-cyclonedx-sbom/action.yml` is now required and must be in the canonical `sha256:<64-hex>` format, rather than being optional or auto-resolved.
* The SBOM action now validates the digest format explicitly and fails early if the format is invalid, instead of attempting to resolve or guess the digest.

**Workflow Updates:**

* The Docker workflow (`.github/workflows/docker-workflow.yml`) now passes the image and digest as separate inputs to the SBOM action, reflecting the new input requirements. [[1]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bL384-R387) [[2]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bL559-R564)
* The SBOM action reference in the workflow is updated to use the `feat/docker_sbom_cycloneDX` branch instead of `v3`. [[1]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bL384-R387) [[2]](diffhunk://#diff-2e6645e42bea54d7a8f8d040cf1bbd07be78b0adc881be3464ffd6d65b57f69bL559-R564)
* Digest extraction during image push now includes format validation, ensuring only valid digests are used.

**Other:**

* Some unrelated version bumping and release-creation steps were removed from the workflow for simplification.