### PR TITLE
DP-2147: Remove continue-on-error for mobtest in integration build workflow

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -765,7 +765,6 @@ jobs:
           retention-days: 5
 
       - name: Run mobtest
-        continue-on-error: true # TODO: remove continue-on-error when mobtest is stable
         if: ${{ inputs.deployment_project == false }}
         shell: bash
         run: |


### PR DESCRIPTION
- Remove continue-on-error for mobtest in integration build workflow