### PR TITLE
chore: update default version numbers in ROS workflow

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -43,11 +43,11 @@ on:
       MOBTEST_VERSION:
         required: false
         type: string
-        default: "0.0.6.1"
+        default: "0.0.7.2"
       ROS_BUILDTOOLS_TAG:
         required: false
         type: string
-        default: "v2.1.3"
+        default: "3.0.9"
       FLOW_INITIATOR_TAG:
         required: false
         type: string
@@ -55,7 +55,7 @@ on:
       MOBROS_VERSION:
         required: false
         type: string
-        default: "2.1.1.2"
+        default: "2.1.1.6"
       INSTALL_CONFLICT_HANDLING:
         required: false
         type: string


### PR DESCRIPTION
This pull request updates several default version values for dependencies in the `.github/workflows/ros-workflow.yml` workflow file. These updates ensure that the workflow uses the latest versions of key tools and packages.

Dependency version updates:

* Updated the default value of `MOBTEST_VERSION` from `"0.0.6.1"` to `"0.0.7.2"`.
* Updated the default value of `ROS_BUILDTOOLS_TAG` from `"v2.1.3"` to `"3.0.9"`.
* Updated the default value of `MOBROS_VERSION` from `"2.1.1.2"` to `"2.1.1.6"`.

related with: https://github.com/MOV-AI/containers-ros-buildtools/pull/121