### PR TITLE
fix: update publish job to handle multiple distributions in image artifact

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -872,7 +872,10 @@ jobs:
             mkdir -p metadata_artifact tmp_meta
             docker cp $container_id:/tmp/proj_metadata.tar.gz ./metadata_artifact/metadata.tar.gz
 
-            echo "$PUSH_REGISTRY/qa/${{ inputs.product_name }}-noetic:$(cat product.version)">artifacts/product-noetic.image.artifact
+            DISTROS=$(echo '${{ needs.Normalize-Distro-Input.outputs.product_distro_list }}' | jq -r '.[] | .distro')
+            for distro in $DISTROS; do
+              echo "$PUSH_REGISTRY/qa/${{ inputs.product_name }}-${distro}:$(cat product.version)" >> artifacts/product-workspaces.image.artifact
+            done
 
       - name: Un stash dependency_version
         if: ${{ inputs.propagate_project == false }}
@@ -2361,9 +2364,9 @@ jobs:
           cp artifacts/*.json deployment_artifacts
           if [ "${{ inputs.with_simulation }}" = "true" ];
           then
-            echo -e "$(cat ./artifacts/product-noetic.image.artifact)\n$(cat ./simulator.image.artifact)" > deployment_artifacts/product.image.artifact
+            cat ./artifacts/product-workspaces.image.artifact ./simulator.image.artifact > deployment_artifacts/product.image.artifact
           else
-            cp ./artifacts/product-noetic.image.artifact deployment_artifacts/product.image.artifact
+            cp ./artifacts/product-workspaces.image.artifact deployment_artifacts/product.image.artifact
           fi
 
           cp deployment_artifacts/product.image.artifact ./


### PR DESCRIPTION
This pull request updates the integration build workflow to support building and deploying product images for multiple distributions, rather than just the `noetic` distribution. The changes primarily focus on generating and handling image artifact files in a more flexible way.

**Multi-distribution support for product image artifacts:**

* The workflow now iterates over all distributions listed in `product_distro_list` and appends an image artifact line for each, instead of only creating one for `noetic`. (`.github/workflows/integration-build-product.yml`)

* When preparing deployment artifacts, the workflow now combines all product image artifact entries (for all distributions) with the simulator artifact, ensuring that the deployment artifact reflects all relevant images. (`.github/workflows/integration-build-product.yml`)

* In the case where simulation is not included, the workflow copies the multi-distribution product image artifact file instead of the single `noetic` artifact. (`.github/workflows/integration-build-product.yml`)