### PR TITLE
DP-2096 - Feat: SBOM generation on EE platform pipeline

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -304,13 +304,13 @@ jobs:
           python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash raised_meta
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: raised_meta
           path: platform_configs
 
       - name: unstash component_artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: component_artifacts
 
@@ -529,7 +529,7 @@ jobs:
           python3 -m pip install integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash sim_configs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: sim_configs
           path: simulator_artifacts
@@ -724,25 +724,25 @@ jobs:
           echo "ip=$(hostname -I | awk '{print $1}')" | tee $GITHUB_OUTPUT
 
       - name: unstash robot_configs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: robot_configs
           path: .
 
       - name: unstash raised_meta
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: raised_meta
           path: platform_configs
 
       - name: unstash deploy_artifacts_noetic
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: deploy_artifacts_noetic
           path: artifacts
 
       - name: unstash deploy_simulator_artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: deploy_simulator_artifacts
           path: .
@@ -956,7 +956,7 @@ jobs:
     if: ${{ always() && ( needs.publish.result == 'failure' || needs.publish.result == 'cancelled'  || needs.publish.result == 'skipped') }}
     steps:
       - name: unstash raised_meta
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: raised_meta
           path: platform_configs

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -56,6 +56,11 @@ on:
         type: boolean
         default: true
         description: Flag to enable/disable the Robotic Stack Integration tests
+      generate_sbom:
+        required: false
+        type: boolean
+        default: true
+        description: Generate CycloneDX SBOM and attach it as Harbor accessory for pushed images
       provision_tf_env_repo:
         required: false
         type: string
@@ -574,7 +579,8 @@ jobs:
 
       - name: Build with args and push
         if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        id: build_simulator
         with:
           context: .
           platforms: linux/amd64
@@ -585,6 +591,15 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ steps.pre_build.outputs.base_name }}
             CI_SCRIPT_VERSION=${{ env.CI_INTEGRATION_SCRIPTS_VERSION }}
+
+      - name: Generate and attach simulator CycloneDX SBOM
+        if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' && inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
+        with:
+          image: ${{ env.REGISTRY }}/qa/${{ steps.pre_build.outputs.image_name }}
+          digest: ${{ steps.build_simulator.outputs.digest }}
+          sbom_file: sbom-simulator.cyclonedx.json
+          artifact_name: sbom-simulator
 
       - name: Collect Installed components
         if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
@@ -785,7 +800,14 @@ jobs:
           docker pull $source
           echo "tagging $source as $target"
           docker tag $source $target
-          docker push $target
+          PUSH_OUTPUT="$(docker push $target 2>&1)"
+          echo "$PUSH_OUTPUT"
+          PUSH_DIGEST="$(printf '%s\n' "${PUSH_OUTPUT}" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)"
+          if [ -z "${PUSH_DIGEST}" ] || ! [[ "${PUSH_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Failed to capture digest for pushed image ${target}"
+            exit 1
+          fi
+          echo "digest=${PUSH_DIGEST}" | tee -a "$GITHUB_OUTPUT"
 
           cp product.version deployment_artifacts
           cp product-manifest.yaml deployment_artifacts
@@ -809,6 +831,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+      - name: Generate and attach backend CycloneDX SBOM
+        if: ${{ inputs.generate_sbom }}
+        uses: MOV-AI/.github/.github/actions/attach-cyclonedx-sbom@v3
+        with:
+          image: "${{env.PUSH_REGISTRY}}/qa/${{ needs.Validations-Finish.outputs.backend_image }}"
+          digest: ${{ steps.prepare_publish.outputs.digest }}
+          sbom_file: sbom-backend.cyclonedx.json
+          artifact_name: sbom-backend
+
       - name: Prepare raise variables
         id: pre_raise
         run: |
@@ -823,6 +854,13 @@ jobs:
           branch: ${{ steps.pre_raise.outputs.branch }}
           repository: ${{ github.repository }}
 
+      - name: Download CycloneDX SBOM artifacts
+        if: ${{ inputs.generate_sbom }}
+        uses: actions/download-artifact@v8
+        with:
+          pattern: sbom-*
+          merge-multiple: true
+
       - name: Github Publish
         shell: bash
         run: |
@@ -835,6 +873,8 @@ jobs:
           gh release create -p --generate-notes $previous_version_option --target "$commit_hash" -t "${{ inputs.product_name }} $product_version" $product_version
           # add all files in the deployment_artifacts folder
           find deployment_artifacts -type f -exec gh release upload $product_version {} \;
+          # add all CycloneDX SBOM files
+          find . -name "sbom-*.cyclonedx.json" -type f -exec gh release upload $product_version {} \;
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 


### PR DESCRIPTION
This pull request enhances the integration build workflow by adding support for generating and attaching CycloneDX SBOMs (Software Bill of Materials) for built images, improves image digest handling, and upgrades the Docker build action. The main changes are grouped below.

**SBOM Generation and Attachment:**

* Added a new `generate_sbom` input to control whether CycloneDX SBOMs are generated and attached for built images.
* Integrated steps to generate and attach CycloneDX SBOMs for both the simulator and backend images using the `attach-cyclonedx-sbom` action. [[1]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535R595-R603) [[2]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535R834-R842)
* Added a step to download all generated SBOM artifacts for inclusion in the release.
* Modified the release publishing step to upload all SBOM files as part of the GitHub release.

**Docker Build and Image Digest Handling:**

* Upgraded the Docker build-push action from v5 to v6 and improved the logic for capturing and exporting the pushed image digest for later use (e.g., in SBOM attachment). [[1]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535L577-R583) [[2]](diffhunk://#diff-dbd6981ee068133d9398fa5fdbf0664493ad90c34aedbb22a49c5add62b91535L788-R810)