### PR TITLE
DP-2156: update PROVISION_INFRA_VERSION to 2.2.0-3 in integration-build-product.yml

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -156,7 +156,7 @@ env:
   USERSPACE_FOLDER_PATH: /opt/movai/userspace
   REMOTE_WORKSPACE_PATH: workspace
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
-  PROVISION_INFRA_VERSION: "2.2.0-2"
+  PROVISION_INFRA_VERSION: "2.2.0-3"
   DEVOPS_SLACK_CHANNEL: "G0102LEV1CL"
   # slack channel movai-projects
   SLACK_CHANNEL: ${{ inputs.overwrite_slack_channel }}


### PR DESCRIPTION
fixes: a stopped VM on kx-02 can block nightlies due to a resource mapping being already created