### PR TITLE
DP-2096: publish SBOMs on projects

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2643,6 +2643,8 @@ jobs:
 
       - name: Publish SBOMs to Dependency Track
         if: ${{ inputs.generate_sbom }}
+        continue-on-error: true
+        shell: bash
         run: |
           set -o pipefail
           rm -rf deployment_artifacts/publish-sbom/

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -129,6 +129,9 @@ on:
         required: true
       provision_infra_pwd:
         required: true
+      dependency_track_api_key:
+        required: false
+
     outputs:
       init_version:
         description: "Version of the product before built"
@@ -167,6 +170,8 @@ env:
   MINIO_PUBLIC_URL: "https://minio.mov.ai"
   TIMEOUT: 720
   PROVISIONING_ENV_CONF: "0.2.2-5"
+  DEPENDENCY_TRACK_URL: "https://sbom.es.mov.ai"
+  HARBOR_URL: "https://registry.cloud.mov.ai/"
 
 jobs:
   Compute-timeout:
@@ -2236,7 +2241,7 @@ jobs:
           fi
           echo -e "## ${{ github.job }} Summary\n${summary_message}" >> $GITHUB_STEP_SUMMARY
 
-  publish-prepare:
+  Publish-Prepare:
     needs: [Validate-boostrap-configs, Install-Robot, Install-Simulator-Robot, Validation-Simulator-Tests]
     runs-on: integration-pipeline
     outputs:
@@ -2442,14 +2447,14 @@ jobs:
           path: deployment_artifacts/*
           retention-days: 7
 
-  generate-sbom:
-    needs: [publish-prepare]
-    if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.publish-prepare.outputs.sbom_matrix != '' && needs.publish-prepare.outputs.sbom_matrix != '[]' }}
+  Generate-SBOM:
+    needs: [Publish-Prepare]
+    if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Publish-Prepare.outputs.sbom_matrix != '' && needs.Publish-Prepare.outputs.sbom_matrix != '[]' }}
     runs-on: integration-pipeline
     strategy:
       fail-fast: false
       matrix:
-        image_target: ${{ fromJSON(needs.publish-prepare.outputs.sbom_matrix) }}
+        image_target: ${{ fromJSON(needs.Publish-Prepare.outputs.sbom_matrix) }}
     steps:
       - name: Login to ${{ env.PUSH_REGISTRY }} Registry
         uses: docker/login-action@v4
@@ -2466,17 +2471,19 @@ jobs:
           sbom_file: sbom-${{ matrix.image_target.name }}.cyclonedx.json
           artifact_name: sbom-${{ matrix.image_target.name }}
 
-  publish:
-    needs: [Validate-boostrap-configs, Install-Simulator-Robot, publish-prepare, generate-sbom]
+  Publish:
+    needs: [Validate-boostrap-configs, Install-Simulator-Robot, Publish-Prepare, Generate-SBOM]
     if: ${{ always() }}
     runs-on: integration-pipeline
     outputs:
       slack_thread_id: ${{ needs.Install-Simulator-Robot.outputs.slack_thread_id }}
     container:
-      image: registry.aws.cloud.mov.ai/qa/py-buildserver:v3.0.3
+      image: registry.aws.cloud.mov.ai/qa/py-buildserver:v4.0.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}
+    env:
+      CI_INTEGRATION_SCRIPTS_VERSION: "4.3.0.4"
     steps:
       - uses: rtCamp/action-cleanup@master
         if: ${{ inputs.is_nightly_run == false && github.event_name != 'pull_request' }}
@@ -2484,6 +2491,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         if: ${{ inputs.is_nightly_run == false && github.event_name != 'pull_request' }}
+
+      - name: Install CI Scripts in container
+        shell: bash
+        run: |
+          python3 -m pip install -q integration-pipeline==$CI_INTEGRATION_SCRIPTS_VERSION --ignore-installed
 
       - name: unstash raised_meta
         if: ${{ inputs.is_nightly_run == false && github.event_name != 'pull_request' }}
@@ -2515,7 +2527,7 @@ jobs:
           git config --global user.password ${{ secrets.auto_commit_pwd }}
 
           cp ./platform_configs/.bumpversion.cfg .bumpversion.cfg
-          echo "${{ needs.publish-prepare.outputs.version }}" > product.version
+          echo "${{ needs.Publish-Prepare.outputs.version }}" > product.version
 
           git add product.version
           git add .bumpversion.cfg
@@ -2536,7 +2548,7 @@ jobs:
           repository: ${{ github.repository }}
 
       - name: Download CycloneDX SBOM artifacts
-        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.generate-sbom.result == 'success' }}
+        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           pattern: sbom-*
@@ -2547,10 +2559,10 @@ jobs:
         shell: bash
         run: |
           commit_hash=$(git log --format="%H" -n 1)
-          product_version="${{ needs.publish-prepare.outputs.version }}"
+          product_version="${{ needs.Publish-Prepare.outputs.version }}"
           previous_version_option=""
-          if gh release view ${{ needs.publish-prepare.outputs.previous_version }}  &>/dev/null; then
-            previous_version_option="--notes-start-tag ${{ needs.publish-prepare.outputs.previous_version }}"
+          if gh release view ${{ needs.Publish-Prepare.outputs.previous_version }}  &>/dev/null; then
+            previous_version_option="--notes-start-tag ${{ needs.Publish-Prepare.outputs.previous_version }}"
           fi
           gh release create -p --generate-notes $previous_version_option --target "$commit_hash" -t "${{ inputs.product_name }} $product_version" $product_version
 
@@ -2566,7 +2578,7 @@ jobs:
         if: ${{ inputs.is_nightly_run == false && github.event_name != 'pull_request' }}
         run: |
           # release version
-          product_version="${{ needs.publish-prepare.outputs.version }}"
+          product_version="${{ needs.Publish-Prepare.outputs.version }}"
 
           # get existent release body
           ORIGINAL_RN=$(gh release view "${product_version}" --json body | jq -r .body)
@@ -2629,6 +2641,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+      - name: Publish SBOMs to Dependency Track
+        if: ${{ inputs.generate_sbom }}
+        run: |
+          set -o pipefail
+          rm -rf deployment_artifacts/publish-sbom/
+          mkdir  -p deployment_artifacts/publish-sbom/
+          chmod -R 755 deployment_artifacts/publish-sbom/
+          integration-pipeline publish_sbom_to_dependency_track \
+            --manifest_file deployment_artifacts/product-manifest.yaml \
+            --manifest_platform_base_key product_components \
+            --dependency_track_url ${{ env.DEPENDENCY_TRACK_URL }} \
+            --dependency_track_api_key ${{ secrets.dependency_track_api_key }} \
+            --harbor_url ${{ env.HARBOR_URL }} \
+            --harbor_user ${{ secrets.registry_user }} \
+            --harbor_password ${{ secrets.registry_password }} \
+            --is_latest \
+            --regenerate_bad_sboms \
+            --artifacts_output_dir deployment_artifacts/publish-sbom/ | tee deployment_artifacts/publish-sbom/publish-sbom.log
+
       - name: Propagate release
         continue-on-error: true
         if: ${{ inputs.propagate_project && inputs.is_nightly_run == false && github.event_name != 'pull_request' }}
@@ -2637,7 +2668,7 @@ jobs:
           gh workflow run "Propagate base project dependency to projects - On Dispatch" \
             --repo MOV-AI/qa-automations \
             -f repo_name=${GITHUB_REPOSITORY#*/} \
-            -f repo_version=${{ needs.publish-prepare.outputs.version }}
+            -f repo_version=${{ needs.Publish-Prepare.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
@@ -2669,8 +2700,8 @@ jobs:
 
   Run-Status:
     runs-on: ubuntu-22.04
-    needs: [publish, Validate-boostrap-configs]
-    if: ${{ always() && ( needs.publish.result == 'failure' || needs.publish.result == 'cancelled' || needs.publish.result == 'skipped' ) }}
+    needs: [Publish, Validate-boostrap-configs]
+    if: ${{ always() && ( needs.Publish.result == 'failure' || needs.Publish.result == 'cancelled' || needs.Publish.result == 'skipped' ) }}
     steps:
       - name: unstash raised_meta
         uses: actions/download-artifact@v8

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2642,7 +2642,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Publish SBOMs to Dependency Track
-        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' && secrets.dependency_track_api_key != '' }}
+        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' }}
         continue-on-error: true
         shell: bash
         run: |

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2642,7 +2642,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Publish SBOMs to Dependency Track
-        if: ${{ inputs.generate_sbom }}
+        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' && secrets.dependency_track_api_key != '' }}
         continue-on-error: true
         shell: bash
         run: |

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2478,7 +2478,7 @@ jobs:
     outputs:
       slack_thread_id: ${{ needs.Install-Simulator-Robot.outputs.slack_thread_id }}
     container:
-      image: registry.aws.cloud.mov.ai/qa/py-buildserver:v4.0.1
+      image: registry.aws.cloud.mov.ai/qa/py-buildserver:4.0.1
       credentials:
         username: ${{secrets.registry_user}}
         password: ${{secrets.registry_password}}

--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2641,6 +2641,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
+      - name: Login to ${{ env.PUSH_REGISTRY }} Registry
+        if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.registry_user }}
+          password: ${{ secrets.registry_password }}
+          registry: ${{ env.PUSH_REGISTRY }}
+
       - name: Publish SBOMs to Dependency Track
         if: ${{ inputs.generate_sbom && inputs.is_nightly_run == false && github.event_name != 'pull_request' && needs.Generate-SBOM.result == 'success' }}
         continue-on-error: true


### PR DESCRIPTION
This pull request updates the integration build workflow to improve SBOM (Software Bill of Materials) handling, enhance integration with Dependency Track, and standardize job naming and references. The main changes include publishing SBOMs to Dependency Track, adding new environment variables and secrets, updating job names to PascalCase, and upgrading the CI container image.

**SBOM and Dependency Track Integration:**

* Added a step to publish SBOMs to Dependency Track using the `integration-pipeline` tool and new environment variables (`DEPENDENCY_TRACK_URL`, `HARBOR_URL`) and secret (`dependency_track_api_key`). 

**Workflow Job Naming and Reference Standardization:**

* Renamed jobs (e.g., `publish-prepare` → `Publish-Prepare`, `generate-sbom` → `Generate-SBOM`, `publish` → `Publish`) and updated all related references to use PascalCase for consistency. 

**CI Environment and Container Updates:**

* Upgraded the CI container image to `py-buildserver:v4.0.1` and set `CI_INTEGRATION_SCRIPTS_VERSION` to `4.3.0.4`, ensuring the latest integration scripts are installed in the container.

These changes improve traceability, automation, and integration with external SBOM management systems, while also making the workflow easier to maintain and extend.