### PR TITLE
DP-2096 - Update manifest_platform_base_key for SBOM publishing

### DIFF
--- a/.github/workflows/integration-build-product.yml
+++ b/.github/workflows/integration-build-product.yml
@@ -2660,7 +2660,7 @@ jobs:
           chmod -R 755 deployment_artifacts/publish-sbom/
           integration-pipeline publish_sbom_to_dependency_track \
             --manifest_file deployment_artifacts/product-manifest.yaml \
-            --manifest_platform_base_key product_components \
+            --manifest_platform_base_key product_components,product_dependencies \
             --dependency_track_url ${{ env.DEPENDENCY_TRACK_URL }} \
             --dependency_track_api_key ${{ secrets.dependency_track_api_key }} \
             --harbor_url ${{ env.HARBOR_URL }} \


### PR DESCRIPTION
This pull request makes a small but important update to the integration build workflow by modifying the SBOM publishing step. The change ensures that both `product_components` and `product_dependencies` are included as base keys when publishing the SBOM to Dependency Track.

* Updated the `publish_sbom_to_dependency_track` step in `.github/workflows/integration-build-product.yml` to include both `product_components` and `product_dependencies` in the `--manifest_platform_base_key` argument, ensuring more comprehensive SBOM data is published.