### PR TITLE
DP-2162: Backward compatibility for backend .ci files with distro suffix

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -354,9 +354,18 @@ jobs:
         id: pre_build
         shell: bash
         run: |
-          echo "base_name=$(cat backend_base_name.ci)" >> $GITHUB_OUTPUT
-          echo "base_version=$(cat backend_base_version.ci)" >> $GITHUB_OUTPUT
-          echo "raised_version=$(cat product.version)" >> $GITHUB_OUTPUT
+          version=$(cat product.version)
+          major=${version%%.*}
+
+          if (( major < 3 )); then
+            ext="_${{ matrix.workspace['distro'] }}"
+          else
+            ext=""
+          fi
+
+          echo "base_name=$(cat backend_base_name${ext}.ci)" >> "$GITHUB_OUTPUT"
+          echo "base_version=$(cat backend_base_version${ext}.ci)" >> "$GITHUB_OUTPUT"
+          echo "raised_version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This pull request updates the pre-build step in the `.github/workflows/integration-build-platform.yml` workflow to handle version-specific logic for backend base files. The main improvement is that the workflow now dynamically selects the appropriate backend base files based on the major version found in `product.version`.

**Workflow improvements:**

* The pre-build script now checks the major version in `product.version` and, if it's less than 3, appends the current distro to the backend base file names (e.g., `backend_base_name_<distro>.ci`). For version 3 and above, it uses the default file names. This ensures the correct base files are used for different platform versions.

Following the logic inside integration-pipeline while creating the files:
https://github.com/MOV-AI/integration-pipeline-ci-scripts/blob/c2d205cd9f5e7c5c6534242cc7281aa0ab0ba890/integration_pipeline/generate_meta_artifacts/generate_meta_artifacts_executer.py#L144

Related to: https://github.com/MOV-AI/.github/commit/bab49f1114dcd22fc5c07863477f38f44b9c4227

Error: https://github.com/MOV-AI/ee-project-platform/actions/runs/29577025268/job/87873901869#step:15:4