### PR TITLE
DP-2161: Ability to create python packages and deb packages from the same repo

### DIFF
--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -280,11 +280,11 @@ jobs:
             exit 1
         fi
 
-    - name: Install Mobros
+    - name: Install Mobros and build tools
       run: |
         python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
         # pin setuptools version after mobros install to preserve ROS2/colcon compatibility
-        python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel
+        python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel build
 
     - name: Setup link to Ros userspace
       run: |
@@ -313,6 +313,53 @@ jobs:
         export MOVAI_OUTPUT_DIR="$(pwd)/artifacts"
         mobros pack --workspace="$(pwd)" --mode ${{ matrix.build_mode }}
 
+    - name: Check for Python packages
+      id: check_setup
+      shell: bash
+      run: |
+        echo "Searching for Python packages with setup.py..."
+        # Find all directories with setup.py files (excluding .git and .github directories)
+        if find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | grep -q .; then
+          echo "setup_found=true" >> $GITHUB_OUTPUT
+          echo "✓ Found setup.py file(s), will proceed with wheel building"
+        else
+          echo "setup_found=false" >> $GITHUB_OUTPUT
+          echo "No setup.py files found, skipping wheel building"
+        fi
+
+    - name: Build Python wheels
+      if: steps.check_setup.outputs.setup_found == 'true'
+      shell: bash
+      run: |
+        # Find all directories with setup.py files (excluding .git and .github directories)
+        find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
+          pkg_dir=$(dirname "$setup_file")
+          echo "Building wheel for: $pkg_dir"
+
+          # Check if this is a ROS package (has package.xml)
+          if [ -f "$pkg_dir/package.xml" ]; then
+            echo "Building wheel for ROS package at: $pkg_dir"
+            cd "$pkg_dir"
+
+            # Build the wheel
+            python3 -m build --wheel --no-isolation 2>&1 | tee build.log
+
+            # Check if build was successful
+            if [ ${PIPESTATUS[0]} -eq 0 ]; then
+              # Copy wheels to artifacts directory
+              if [ -d "dist" ]; then
+                mkdir -p "$(pwd)/../../artifacts"
+                cp dist/*.whl "$(pwd)/../../artifacts/" || echo "No wheels found in dist directory"
+                echo "✓ Successfully built wheels for $pkg_dir"
+              fi
+            else
+              echo "⚠ Warning: Failed to build wheel for $pkg_dir"
+            fi
+
+            cd - > /dev/null
+          fi
+        done
+
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests && matrix.distro == 'noetic' }}
       shell: bash
@@ -329,7 +376,8 @@ jobs:
 
     - name: Print generated packages
       run: |
-        ls -la artifacts
+        echo "=== Debian packages ===" && ls -la artifacts/*.deb 2>/dev/null || echo "No .deb files"
+        echo "=== Python wheels ===" && ls -la artifacts/*.whl 2>/dev/null || echo "No .whl files"
 
     - name: Print generated rosdep
       run: |
@@ -584,6 +632,25 @@ jobs:
             fi
           done
 
+    - name: Publish wheels to PyPI Experimental
+      if: ${{ secrets.nexus_publisher_user != '' }}
+      shell: bash
+      run: |
+          WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
+          if [ "$WHEEL_COUNT" -gt 0 ]; then
+            echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Experimental"
+            python3 -m pip install twine --quiet
+
+            twine upload artifacts/*.whl \
+              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-experimental" \
+              --username ${{ secrets.nexus_publisher_user }} \
+              --password ${{ secrets.nexus_publisher_password }} \
+              --non-interactive \
+              --skip-existing
+          else
+            echo "No wheels found, skipping PyPI publish"
+          fi
+
     - name: Commit raise version
       id: raise
       shell: bash
@@ -677,7 +744,7 @@ jobs:
         git config --global --add safe.directory "$(pwd)"
         mkdir artifacts
         cd artifacts
-        gh release download "${{ steps.vars.outputs.tag}}" -p "*.deb"
+        gh release download "${{ steps.vars.outputs.tag}}" -p "*.deb" -p "*.whl"
       env:
         GITHUB_TOKEN: ${{ secrets.gh_token }}
 
@@ -715,3 +782,22 @@ jobs:
                 exit 1
               fi
             done
+
+    - name: Publish wheels to PyPI Integration
+      if: ${{ secrets.nexus_publisher_user != '' }}
+      shell: bash
+      run: |
+          WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
+          if [ "$WHEEL_COUNT" -gt 0 ]; then
+            echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Integration"
+            python3 -m pip install twine --quiet
+
+            twine upload artifacts/*.whl \
+              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-integration" \
+              --username ${{ secrets.nexus_publisher_user }} \
+              --password ${{ secrets.nexus_publisher_password }} \
+              --non-interactive \
+              --skip-existing
+          else
+            echo "No wheels found, skipping PyPI publish"
+          fi

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -788,14 +788,11 @@ jobs:
           WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
           if [ "$WHEEL_COUNT" -gt 0 ]; then
             echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Integration"
-            python3 -m pip install twine --quiet
-
-            twine upload artifacts/*.whl \
-              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-integration" \
-              --username ${{ secrets.nexus_publisher_user }} \
-              --password ${{ secrets.nexus_publisher_password }} \
-              --non-interactive \
-              --skip-existing
+            python3 -m pip install twine
+            python3 -m twine upload --repository-url https://artifacts.aws.cloud.mov.ai/repository/pypi-integration/ \
+            --username "${{ secrets.nexus_publisher_user }}" \
+            --password "${{ secrets.nexus_publisher_password }}" \
+            artifacts/*.whl
           else
             echo "No wheels found, skipping PyPI publish"
           fi

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -351,8 +351,8 @@ jobs:
             if [ ${PIPESTATUS[0]} -eq 0 ]; then
               # Copy wheels to artifacts directory
               if [ -d "dist" ]; then
-                mkdir -p "$(pwd)/../../artifacts"
-                cp dist/*.whl "$(pwd)/../../artifacts/" || echo "No wheels found in dist directory"
+                mkdir -p "../artifacts"
+                cp dist/*.whl "../artifacts/" || echo "No wheels found in dist directory"
                 echo "✓ Successfully built wheels for $pkg_dir"
               fi
             else

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Check if pre-commit config exists
@@ -206,7 +206,7 @@ jobs:
         password: ${{secrets.registry_password}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Run static analysis
@@ -233,7 +233,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -382,7 +382,7 @@ jobs:
         catkin test
 
     - name: Archive binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: packages
         path: artifacts/*
@@ -418,12 +418,12 @@ jobs:
         password: ${{secrets.registry_password}}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: packages
         path: artifacts
@@ -457,7 +457,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
@@ -520,13 +520,13 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ inputs.install_test }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Download artifacts
         if: ${{ inputs.install_test }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: packages
           path: artifacts
@@ -583,13 +583,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.head_ref || github.ref_name }}
         submodules: recursive
 
     - name: Download a single artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: packages
         path: artifacts
@@ -744,7 +744,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -334,21 +334,6 @@ jobs:
       if: steps.check_setup.outputs.setup_found == 'true'
       shell: bash
       run: |
-        export BUILD_ID=$(grep build_version "$(cat /tmp/main-package.mobrosinfo)" | sed 's/ //g; s/<\w*>//g; s/<\/\w*>//g')
-
-        # create a memory hook so setuptools adds .post<buildid>
-        mkdir -p /tmp/wheel_hook
-        cat << 'EOF' > /tmp/wheel_hook/sitecustomize.py
-        import os, setuptools
-        _old_setup = setuptools.setup
-        def _hook(**kw):
-            if "version" in kw and os.environ.get("BUILD_ID"):
-                kw["version"] += f".post{os.environ['BUILD_ID']}"
-            return _old_setup(**kw)
-        setuptools.setup = _hook
-        EOF
-        export PYTHONPATH="/tmp/wheel_hook:$PYTHONPATH"
-
         find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
           pkg_dir=$(dirname "$setup_file")
           echo "Building wheel for: $pkg_dir"

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -633,7 +633,6 @@ jobs:
           done
 
     - name: Publish wheels to PyPI Experimental
-      if: ${{ secrets.nexus_publisher_user != '' }}
       shell: bash
       run: |
           WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
@@ -784,7 +783,6 @@ jobs:
             done
 
     - name: Publish wheels to PyPI Integration
-      if: ${{ secrets.nexus_publisher_user != '' }}
       shell: bash
       run: |
           WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -400,7 +400,7 @@ jobs:
           WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
           if [ "$WHEEL_COUNT" -gt 0 ]; then
             echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Experimental"
-
+            python3 -m pip install twine
             python3 -m twine upload --repository-url https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/ \
             --username "${{ secrets.nexus_publisher_user }}" \
             --password "${{ secrets.nexus_publisher_password }}" \

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -334,6 +334,7 @@ jobs:
       if: steps.check_setup.outputs.setup_found == 'true'
       shell: bash
       run: |
+        export _PYTHON_BUILD_WHEEL_PKG=1
         find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
           pkg_dir=$(dirname "$setup_file")
           echo "Building wheel for: $pkg_dir"

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -283,8 +283,11 @@ jobs:
     - name: Install Mobros and build tools
       run: |
         python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-edge/simple --extra-index-url https://pypi.org/simple mobros==${{ inputs.MOBROS_VERSION }} --ignore-installed
-        # pin setuptools version after mobros install to preserve ROS2/colcon compatibility
-        python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel build
+        if [ "${{ matrix.distro }}" = "noetic" ]; then
+          python3 -m pip install --upgrade wheel build
+        else
+          python3 -m pip install --upgrade 'setuptools>=70.0,<80' jaraco-functools wheel build
+        fi
 
     - name: Setup link to Ros userspace
       run: |

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -400,14 +400,12 @@ jobs:
           WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
           if [ "$WHEEL_COUNT" -gt 0 ]; then
             echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Experimental"
-            python3 -m pip install twine --quiet
 
-            twine upload artifacts/*.whl \
-              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-experimental" \
-              --username ${{ secrets.nexus_publisher_user }} \
-              --password ${{ secrets.nexus_publisher_password }} \
-              --non-interactive \
-              --skip-existing
+            python3 -m twine upload --repository-url https://artifacts.aws.cloud.mov.ai/repository/pypi-experimental/ \
+            --username "${{ secrets.nexus_publisher_user }}" \
+            --password "${{ secrets.nexus_publisher_password }}" \
+            artifacts/*.whl
+
           else
             echo "No wheels found, skipping PyPI publish"
           fi

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -336,10 +336,6 @@ jobs:
       run: |
         buildid=$(grep build_version "$(cat /tmp/main-package.mobrosinfo)" | sed 's/ //g; s/<\w*>//g; s/<\/\w*>//g')
 
-        if [ -n "$buildid" ]; then
-          find . -name "package.xml" ! -path '*/.git/*' ! -path '*/.github/*' -exec sed -i "s/<\/version>/-${buildid}<\/version>/g" {} +
-        fi
-
         find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
           pkg_dir=$(dirname "$setup_file")
           echo "Building wheel for: $pkg_dir"
@@ -354,10 +350,20 @@ jobs:
 
             # Check if build was successful
             if [ ${PIPESTATUS[0]} -eq 0 ]; then
-              # Copy wheels to artifacts directory
               if [ -d "dist" ]; then
                 mkdir -p "../artifacts"
-                cp dist/*.whl "../artifacts/" || echo "No wheels found in dist directory"
+
+                for wheel in dist/*.whl; do
+                  [ -e "$wheel" ] || continue
+
+                  wheel_name=$(basename "$wheel")
+                  renamed_wheel=$(echo "$wheel_name" | \
+                    sed -E "s/^(.+)-([0-9]+\.[0-9]+\.[0-9]+)-(.*)\.whl$/\1-\2-${buildid}-\3.whl/")
+
+                  cp "$wheel" "../artifacts/$renamed_wheel"
+                  echo "Copied as: $renamed_wheel"
+                done
+
                 echo "✓ Successfully built wheels for $pkg_dir"
               fi
             else
@@ -367,10 +373,6 @@ jobs:
             cd - > /dev/null
           fi
         done
-
-        if [ -n "$buildid" ]; then
-          find . -name "package.xml" ! -path '*/.git/*' ! -path '*/.github/*' -exec sed -i "s/-${buildid}<\/version>/<\/version>/g" {} +
-        fi
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests && matrix.distro == 'noetic' }}

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -334,7 +334,20 @@ jobs:
       if: steps.check_setup.outputs.setup_found == 'true'
       shell: bash
       run: |
-        buildid=$(grep build_version "$(cat /tmp/main-package.mobrosinfo)" | sed 's/ //g; s/<\w*>//g; s/<\/\w*>//g')
+        export BUILD_ID=$(grep build_version "$(cat /tmp/main-package.mobrosinfo)" | sed 's/ //g; s/<\w*>//g; s/<\/\w*>//g')
+
+        # create a memory hook so setuptools adds .post<buildid>
+        mkdir -p /tmp/wheel_hook
+        cat << 'EOF' > /tmp/wheel_hook/sitecustomize.py
+        import os, setuptools
+        _old_setup = setuptools.setup
+        def _hook(**kw):
+            if "version" in kw and os.environ.get("BUILD_ID"):
+                kw["version"] += f".post{os.environ['BUILD_ID']}"
+            return _old_setup(**kw)
+        setuptools.setup = _hook
+        EOF
+        export PYTHONPATH="/tmp/wheel_hook:$PYTHONPATH"
 
         find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
           pkg_dir=$(dirname "$setup_file")
@@ -352,22 +365,11 @@ jobs:
             if [ ${PIPESTATUS[0]} -eq 0 ]; then
               if [ -d "dist" ]; then
                 mkdir -p "../artifacts"
-
-                for wheel in dist/*.whl; do
-                  [ -e "$wheel" ] || continue
-
-                  wheel_name=$(basename "$wheel")
-                  renamed_wheel=$(echo "$wheel_name" | \
-                    sed -E "s/^(.+)-([0-9]+\.[0-9]+\.[0-9]+)-(.*)\.whl$/\1-\2-${buildid}-\3.whl/")
-
-                  cp "$wheel" "../artifacts/$renamed_wheel"
-                  echo "Copied as: $renamed_wheel"
-                done
-
-                echo "✓ Successfully built wheels for $pkg_dir"
+                cp dist/*.whl "../artifacts/" || echo "No wheels found in dist directory"
+                echo "Successfully built wheels for $pkg_dir"
               fi
             else
-              echo "⚠ Warning: Failed to build wheel for $pkg_dir"
+              echo "Failed to build wheel for $pkg_dir"
             fi
 
             cd - > /dev/null
@@ -405,6 +407,24 @@ jobs:
         export AWS_SECRET_ACCESS_KEY='${{ secrets.aws_sqs_rosdep_secret_access_key }}'
         mobros publish
         cat /usr/local/rosdep/ros-pkgs.yaml
+
+    - name: Publish wheels to PyPI Experimental
+      shell: bash
+      run: |
+          WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
+          if [ "$WHEEL_COUNT" -gt 0 ]; then
+            echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Experimental"
+            python3 -m pip install twine --quiet
+
+            twine upload artifacts/*.whl \
+              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-experimental" \
+              --username ${{ secrets.nexus_publisher_user }} \
+              --password ${{ secrets.nexus_publisher_password }} \
+              --non-interactive \
+              --skip-existing
+          else
+            echo "No wheels found, skipping PyPI publish"
+          fi
 
   Post-build-static-analysis:
     if: ${{ inputs.release == 'false' && needs.Check-static-analysis-config.outputs.pre_commit_exists == 'true' }}
@@ -645,24 +665,6 @@ jobs:
               exit 1
             fi
           done
-
-    - name: Publish wheels to PyPI Experimental
-      shell: bash
-      run: |
-          WHEEL_COUNT=$(find artifacts -name "*.whl" | wc -l)
-          if [ "$WHEEL_COUNT" -gt 0 ]; then
-            echo "Found $WHEEL_COUNT wheel(s) to publish to PyPI Experimental"
-            python3 -m pip install twine --quiet
-
-            twine upload artifacts/*.whl \
-              --repository-url "https://artifacts.cloud.mov.ai/repository/pypi-experimental" \
-              --username ${{ secrets.nexus_publisher_user }} \
-              --password ${{ secrets.nexus_publisher_password }} \
-              --non-interactive \
-              --skip-existing
-          else
-            echo "No wheels found, skipping PyPI publish"
-          fi
 
     - name: Commit raise version
       id: raise

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -334,7 +334,12 @@ jobs:
       if: steps.check_setup.outputs.setup_found == 'true'
       shell: bash
       run: |
-        # Find all directories with setup.py files (excluding .git and .github directories)
+        buildid=$(grep build_version "$(cat /tmp/main-package.mobrosinfo)" | sed 's/ //g; s/<\w*>//g; s/<\/\w*>//g')
+
+        if [ -n "$buildid" ]; then
+          find . -name "package.xml" ! -path '*/.git/*' ! -path '*/.github/*' -exec sed -i "s/<\/version>/-${buildid}<\/version>/g" {} +
+        fi
+
         find . -type f -name "setup.py" ! -path '*/.git/*' ! -path '*/.github/*' | while read -r setup_file; do
           pkg_dir=$(dirname "$setup_file")
           echo "Building wheel for: $pkg_dir"
@@ -362,6 +367,10 @@ jobs:
             cd - > /dev/null
           fi
         done
+
+        if [ -n "$buildid" ]; then
+          find . -name "package.xml" ! -path '*/.git/*' ! -path '*/.github/*' -exec sed -i "s/-${buildid}<\/version>/<\/version>/g" {} +
+        fi
 
     - name: Run Catkin tests
       if: ${{ inputs.run_catkin_tests && matrix.distro == 'noetic' }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [docs/workflows.md](docs/workflows.md) for detailed specifications, inputs, 
 |----------|---------|
 | **Build and Pack FE Packages** | Builds and packages frontend packages for the MOV.AI platform |
 | **Build and Pack Npm Components** | Builds and packages npm components for the MOV.AI platform |
-| **Build and Pack ROS Packages** | Builds and publishes ROS packages (Debian) for ROS 1 (Noetic) and ROS 2 (Humble) |
+| **Build and Pack ROS Packages** | Builds and publishes ROS packages (Debian) for ROS 1 (Noetic) and ROS 2 (Humble). Automatically builds and publishes Python wheel packages for ROS packages containing a setup.py file. |
 | **Build and Validate Platform** | Builds and validates the MOV.AI platform |
 | **Build Docker Images** | Builds and publishes Docker images with static analysis, Snyk scanning, and optional multi-platform support |
 | **Build Packer Images** | Builds ISO images for CICD using Packer, QEMU/KVM/Libvirt, and cloud-init |


### PR DESCRIPTION
This pull request enhances the CI workflow for ROS projects by adding automated detection and building of Python wheels for packages with `setup.py`, and publishing them to PyPI Experimental and Integration repositories if credentials are available. It also improves artifact reporting and ensures wheels are included in release downloads.

Tested here: https://github.com/MOV-AI/movai_vda5050/pull/37
