### PR TITLE
fix slack issue

### DIFF
--- a/.github/workflows/qa-ui-workflow.yml
+++ b/.github/workflows/qa-ui-workflow.yml
@@ -25,7 +25,7 @@ on:
       slack_channel:
         required: false
         type: string
-        default: 'G0102LEV1CL' #funky-devops
+        default: ''
       with_fleet_tests:
         required: false
         type: boolean


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/qa-ui-workflow.yml` file, updating the default value of the `slack_channel` input to an empty string. This means the workflow will no longer default to posting to a specific Slack channel unless one is explicitly provided.

From the meeting qa said that they didn't want slack messages since this is a automation they are always checking. 