### PR TITLE
fix: update source image logic in fleet tests workflow

### DIFF
--- a/.github/workflows/integration-platform-remote-fleet-tests.yml
+++ b/.github/workflows/integration-platform-remote-fleet-tests.yml
@@ -481,7 +481,12 @@ jobs:
           REGISTRY_USER="${{ secrets.registry_user }}"
           REGISTRY_PASS="${{ secrets.registry_password }}"
 
-          SOURCE_TAG="${REGISTRY}/ci/${BACKEND_IMAGE}"
+          SOURCE_IMAGE="qa"
+          if [[ "${{ inputs.robot_config_download }}" == "true"]]; then
+            SOURCE_IMAGE="ci"
+          fi
+
+          SOURCE_TAG="${REGISTRY}/${SOURCE_IMAGE}/${BACKEND_IMAGE}"
           TARGET_TAG_REGISTRY="${REGISTRY}/qa/${BACKEND_IMAGE}"
           TARGET_TAG_MID_REGISTRY="${MID_REGISTRY}/qa/${BACKEND_IMAGE}"
 


### PR DESCRIPTION
This pull request updates the workflow logic for selecting the source image in the `.github/workflows/integration-platform-remote-fleet-tests.yml` file. The main change is to dynamically set the `SOURCE_IMAGE` based on the value of the `robot_config_download` input.

Workflow logic improvements:

* The `SOURCE_IMAGE` variable is now set to `"qa"` by default, but will be set to `"ci"` if the `robot_config_download` input is `"true"`, allowing for more flexible image selection in the workflow.
* The `SOURCE_TAG` variable is updated to use the new `SOURCE_IMAGE` value, ensuring that the correct image is referenced based on the workflow input.

i used a boolean that already existed for the distinguish between qa_tests and ee but in the future this should be rename