### PR TITLE
DP-2014 (v3): Simplify and Add Backend Standalone Test Validation in Integration Build

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -478,7 +478,7 @@ jobs:
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
       test_timeout: ${{ (matrix.test_key == 'ui_tests' || matrix.test_key == 'flow_initiator') && 120 || 30 }}
-      pytest_args: ${{ matrix.test_key == 'install_tests' && '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
+      pytest_args: ${{ matrix.test_key == 'install_tests' && '-m "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
       xray_label: ${{ matrix.test_key == 'ui_tests' && 'UI_Automation' || '' }}
       slack_channel: ${{ inputs.slack_channel }}
 

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -463,13 +463,13 @@ jobs:
           docker system prune -f
           docker image prune --all -f
 
-  Validation-Standalone-Tests:
-    needs: [Build-backend]
-    if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list) }}
+    Validation-Standalone-Tests:
+        needs: [Build-backend]
+        if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' && needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '' }}
+        strategy:
+          fail-fast: false
+          matrix:
+            test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list || '[]') }}
     uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v2.3
     secrets: inherit
     with:
@@ -492,25 +492,25 @@ jobs:
       - name: Pass through
         run: echo "Pass"
 
-  Fleet-Validations:
-    needs: [Validate-bootstrap-configs, Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-remote-fleet-tests.yml@v3
-    secrets: inherit
-    with:
-      fleet_test_infra_list: ${{ needs.Validate-bootstrap-configs.outputs.fleet_tests_list }}
-      slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
-      backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: 120
-      slack_channel: ${{ inputs.slack_channel }}
-      provision_tf_env_repo: ${{ inputs.provision_tf_env_repo }}
-      provision_tf_env_version: ${{ inputs.provision_tf_env_version }}
-      provision_infra_repo: ${{ inputs.provision_infra_repo }}
-      provision_infra_version: ${{ inputs.provision_infra_version }}
-      fleet_number_members: ${{ inputs.fleet_number_members }}
-      debug_fleet_keep_alive: ${{ inputs.debug_fleet_keep_alive }}
-      fleet_ips: ${{ inputs.fleet_ips }}
-      proxmox_cluster_name: ${{ inputs.proxmox_cluster_name }}
-      with_fleet_tests: ${{ inputs.with_fleet_tests }}
+  # Fleet-Validations:
+  #   needs: [Validate-bootstrap-configs, Build-backend]
+  #   uses: MOV-AI/.github/.github/workflows/integration-platform-remote-fleet-tests.yml@v3
+  #   secrets: inherit
+  #   with:
+  #     fleet_test_infra_list: ${{ needs.Validate-bootstrap-configs.outputs.fleet_tests_list }}
+  #     slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
+  #     backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
+  #     test_timeout: 120
+  #     slack_channel: ${{ inputs.slack_channel }}
+  #     provision_tf_env_repo: ${{ inputs.provision_tf_env_repo }}
+  #     provision_tf_env_version: ${{ inputs.provision_tf_env_version }}
+  #     provision_infra_repo: ${{ inputs.provision_infra_repo }}
+  #     provision_infra_version: ${{ inputs.provision_infra_version }}
+  #     fleet_number_members: ${{ inputs.fleet_number_members }}
+  #     debug_fleet_keep_alive: ${{ inputs.debug_fleet_keep_alive }}
+  #     fleet_ips: ${{ inputs.fleet_ips }}
+  #     proxmox_cluster_name: ${{ inputs.proxmox_cluster_name }}
+  #     with_fleet_tests: ${{ inputs.with_fleet_tests }}
 
   Build-Simulator:
     needs: [Validate-bootstrap-configs]
@@ -766,7 +766,7 @@ jobs:
       simulation_qa_version: ${{ inputs.simulation_qa_version }}
 
   Publish:
-    needs: [Validations-Finish, Fleet-Validations, Simulator-Validations, Robotic-Stack-Integration]
+    needs: [Validations-Finish, Simulator-Validations, Robotic-Stack-Integration]
     runs-on: integration-pipeline
     outputs:
       slack_thread_id: ${{ needs.Validations-Finish.outputs.slack_thread_id }}

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -485,25 +485,25 @@ jobs:
       - name: Pass through
         run: echo "Pass"
 
-  # Fleet-Validations:
-  #   needs: [Validate-bootstrap-configs, Build-backend]
-  #   uses: MOV-AI/.github/.github/workflows/integration-platform-remote-fleet-tests.yml@v3
-  #   secrets: inherit
-  #   with:
-  #     fleet_test_infra_list: ${{ needs.Validate-bootstrap-configs.outputs.fleet_tests_list }}
-  #     slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
-  #     backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-  #     test_timeout: 120
-  #     slack_channel: ${{ inputs.slack_channel }}
-  #     provision_tf_env_repo: ${{ inputs.provision_tf_env_repo }}
-  #     provision_tf_env_version: ${{ inputs.provision_tf_env_version }}
-  #     provision_infra_repo: ${{ inputs.provision_infra_repo }}
-  #     provision_infra_version: ${{ inputs.provision_infra_version }}
-  #     fleet_number_members: ${{ inputs.fleet_number_members }}
-  #     debug_fleet_keep_alive: ${{ inputs.debug_fleet_keep_alive }}
-  #     fleet_ips: ${{ inputs.fleet_ips }}
-  #     proxmox_cluster_name: ${{ inputs.proxmox_cluster_name }}
-  #     with_fleet_tests: ${{ inputs.with_fleet_tests }}
+  Fleet-Validations:
+    needs: [Validate-bootstrap-configs, Build-backend]
+    uses: MOV-AI/.github/.github/workflows/integration-platform-remote-fleet-tests.yml@v3
+    secrets: inherit
+    with:
+      fleet_test_infra_list: ${{ needs.Validate-bootstrap-configs.outputs.fleet_tests_list }}
+      slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
+      backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
+      test_timeout: 120
+      slack_channel: ${{ inputs.slack_channel }}
+      provision_tf_env_repo: ${{ inputs.provision_tf_env_repo }}
+      provision_tf_env_version: ${{ inputs.provision_tf_env_version }}
+      provision_infra_repo: ${{ inputs.provision_infra_repo }}
+      provision_infra_version: ${{ inputs.provision_infra_version }}
+      fleet_number_members: ${{ inputs.fleet_number_members }}
+      debug_fleet_keep_alive: ${{ inputs.debug_fleet_keep_alive }}
+      fleet_ips: ${{ inputs.fleet_ips }}
+      proxmox_cluster_name: ${{ inputs.proxmox_cluster_name }}
+      with_fleet_tests: ${{ inputs.with_fleet_tests }}
 
   Build-Simulator:
     needs: [Validate-bootstrap-configs]

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -478,7 +478,7 @@ jobs:
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
       test_timeout: ${{ (matrix.test_key == 'ui_tests' || matrix.test_key == 'flow_initiator') && 120 || 30 }}
-      pytest_args: ${{ matrix.test_key == 'install_tests' && '-m "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
+      pytest_args: ${{ matrix.test_key == 'install_tests' && '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
       xray_label: ${{ matrix.test_key == 'ui_tests' && 'UI_Automation' || '' }}
       slack_channel: ${{ inputs.slack_channel }}
 

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -154,7 +154,6 @@ env:
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
   PROVISION_INFRA_VERSION: "2.2.0-3"
   ARTIFACTS_RETENTION_DAYS: 15
-  DEFAULT_PYTEST_ARGS: '-m "$test_set" --movai-ip $host_ip --movai-user $movai_user --movai-pw $movai_pwd'
   DEPENDENCY_TRACK_URL: "https://sbom.es.mov.ai"
   HARBOR_URL: "https://registry.cloud.mov.ai/"
 jobs:
@@ -169,7 +168,6 @@ jobs:
       slack_thread_id: ${{ steps.send-message.outputs.ts }}
       fleet_tests_list: ${{ steps.extract_test_lists.outputs.fleet_tests_list }}
       standalone_tests_list: ${{ steps.extract_test_lists.outputs.standalone_tests_list }}
-      default_pytest_args: ${{ steps.default_pytest_args.outputs.args }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -241,10 +239,6 @@ jobs:
               fh.write(f'fleet_tests_list={json.dumps(fleet_tests)}\n')
               fh.write(f'standalone_tests_list={json.dumps(standalone_tests)}\n')
           "
-
-      - name: Pass through default pytest args
-        id: default_pytest_args
-        run: echo "args=${DEFAULT_PYTEST_ARGS}" >> $GITHUB_OUTPUT
 
       - name: Stash component_artifacts
         uses: actions/upload-artifact@v7
@@ -478,7 +472,6 @@ jobs:
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
       test_timeout: ${{ (matrix.test_key == 'ui_tests' || matrix.test_key == 'flow_initiator') && 120 || 30 }}
-      pytest_args: ${{ matrix.test_key == 'install_tests' && '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
       xray_label: ${{ matrix.test_key == 'ui_tests' && 'UI_Automation' || '' }}
       slack_channel: ${{ inputs.slack_channel }}
 

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -464,7 +464,7 @@ jobs:
           docker image prune --all -f
 
   Validation-Standalone-Tests:
-    needs: [Build-backend]
+    needs: [Build-backend, Validation-Standalone-Tests]
     if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' && needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -244,17 +244,7 @@ jobs:
 
       - name: Pass through default pytest args
         id: default_pytest_args
-        shell: bash
-        run: |
-          echo "test_args='${test_args}'"
-          args="${DEFAULT_PYTEST_ARGS}"
-
-          if [[ -n "${test_args:-}" ]]; then
-            args="${test_args} ${DEFAULT_PYTEST_ARGS}"
-            echo "args=${args}"
-          fi
-
-          echo "args=${args}" >> "$GITHUB_OUTPUT"
+        run: echo "args=${DEFAULT_PYTEST_ARGS}" >> $GITHUB_OUTPUT
 
       - name: Stash component_artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -473,7 +473,7 @@ jobs:
     uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v2.3
     secrets: inherit
     with:
-      collect_deployable_artifacts: ${{ matrix.test_key == 'ui_tests' }} || ${{ matrix.test_key == 'install_tests' }}
+      collect_deployable_artifacts: ${{ matrix.test_key == 'ui_tests' || matrix.test_key == 'install_tests' }}
       test_infra_key: ${{ matrix.test_key }}
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -463,13 +463,13 @@ jobs:
           docker system prune -f
           docker image prune --all -f
 
-    Validation-Standalone-Tests:
-        needs: [Build-backend]
-        if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' && needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '' }}
-        strategy:
-          fail-fast: false
-          matrix:
-            test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list || '[]') }}
+  Validation-Standalone-Tests:
+    needs: [Build-backend]
+    if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' && needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list || '[]') }}
     uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v2.3
     secrets: inherit
     with:

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -154,6 +154,7 @@ env:
   PROVISION_INFRA_REPO: "devops-tf-proxmox-bpg"
   PROVISION_INFRA_VERSION: "2.2.0-3"
   ARTIFACTS_RETENTION_DAYS: 15
+  DEFAULT_PYTEST_ARGS: '-m "$test_set" --movai-ip $host_ip --movai-user $movai_user --movai-pw $movai_pwd'
   DEPENDENCY_TRACK_URL: "https://sbom.es.mov.ai"
   HARBOR_URL: "https://registry.cloud.mov.ai/"
 jobs:
@@ -167,6 +168,8 @@ jobs:
     outputs:
       slack_thread_id: ${{ steps.send-message.outputs.ts }}
       fleet_tests_list: ${{ steps.extract_fleet_tests_list.outputs.fleet_tests_list }}
+      standalone_tests_list: ${{ steps.extract_test_lists.outputs.standalone_tests_list }}
+      default_pytest_args: ${{ steps.default_pytest_args.outputs.args }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -210,22 +213,35 @@ jobs:
           mkdir component_artifacts
           cp ci_artifacts/* ./component_artifacts
 
-      - name: Extract fleet tests list
-        id: extract_fleet_tests_list
+      - name: Extract test lists
+        id: extract_test_lists
         run: |
-          FLEET_TESTS=$(python3 -c "
-          import yaml, json
+          python3 -c "
+          import yaml, json, os
           with open('product-manifest.yaml') as f:
               data = yaml.safe_load(f)
-          qa_config = data['product_components']['qa']
-          fleet_test_names = [
+          qa_config = data.get('product_components', {}).get('qa', {})
+
+          # Fleet tests
+          fleet_tests = [
               test_name for test_name, test_config in qa_config.items()
               if isinstance(test_config, dict) and 'fleet' in test_config
           ]
-          print(json.dumps(fleet_test_names))
-          ")
-          echo "fleet_tests_list=${FLEET_TESTS}" >> $GITHUB_OUTPUT
 
+          # Standalone tests (filtering out simul_flow_tests)
+          standalone_tests = [
+              test_name for test_name, test_config in qa_config.items()
+              if isinstance(test_config, dict) and 'standalone' in test_config and test_name != 'simul_flow_tests'
+          ]
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'fleet_tests_list={json.dumps(fleet_tests)}\n')
+              fh.write(f'standalone_tests_list={json.dumps(standalone_tests)}\n')
+          "
+
+      - name: Pass through default pytest args
+        id: default_pytest_args
+        run: echo "args=${DEFAULT_PYTEST_ARGS}" >> $GITHUB_OUTPUT
 
       - name: Stash component_artifacts
         uses: actions/upload-artifact@v7
@@ -444,59 +460,27 @@ jobs:
           docker system prune -f
           docker image prune --all -f
 
-  Validation-UI-Tests:
+  Validation-Standalone-Tests:
     needs: [Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
+    if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list) }}
+    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v2.3
     secrets: inherit
     with:
-      collect_deployable_artifacts: true
-      test_infra_key: "ui_tests"
+      collect_deployable_artifacts: ${{ matrix.test_key == 'ui_tests' }} || ${{ matrix.test_key == 'install_tests' }}
+      test_infra_key: ${{ matrix.test_key }}
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: 120
-      pytest_args: '--movai-ip $host_ip --movai-user $movai_user --movai-pw $movai_pwd --cucumberjson=./results.json'
-      xray_label: "UI_Automation"
-      slack_channel: ${{ inputs.slack_channel }}
-
-  Validation-Install-Tests:
-    needs: [Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
-    secrets: inherit
-    with:
-      collect_deployable_artifacts: true
-      test_infra_key: "install_tests"
-      slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
-      backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: 30
-      pytest_args: '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report'
-      slack_channel: ${{ inputs.slack_channel }}
-
-  Validation-API-Tests:
-    needs: [Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
-    secrets: inherit
-    with:
-      test_infra_key: "api_tests"
-      slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
-      backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: 30
-      pytest_args: '--movai-ip $host_ip --movai-user $movai_user --movai-pw $movai_pwd'
-      slack_channel: ${{ inputs.slack_channel }}
-
-  Validation-Flow-Tests:
-    needs: [Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
-    secrets: inherit
-    with:
-      test_infra_key: "flow_tests"
-      slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
-      backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: 30
-      pytest_args: '-m "$test_set" --movai-ip $host_ip --movai-user $movai_user --movai-pw $movai_pwd'
+      test_timeout: ${{ matrix.test_key == 'ui_tests' && 120 || 30 }}
+      pytest_args: ${{ matrix.test_key == 'install_tests' && '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
+      xray_label: ${{ matrix.test_key == 'ui_tests' && 'UI_Automation' || '' }}
       slack_channel: ${{ inputs.slack_channel }}
 
   Validations-Finish:
-    needs: [Build-backend, Validation-UI-Tests, Validation-Install-Tests, Validation-API-Tests, Validation-Flow-Tests]
+    needs: [Build-backend, Validation-Standalone-Tests]
     runs-on: ubuntu-22.04
     outputs:
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -709,7 +709,7 @@ jobs:
 
   Simulator-Validations:
     needs: [Build-Simulator, Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
+    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@feat/DP-2014_standalone-tests
     secrets: inherit
     with:
       test_infra_key: "simul_flow_tests"

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -234,6 +234,9 @@ jobs:
               if isinstance(test_config, dict) and 'standalone' in test_config and test_name != 'simul_flow_tests'
           ]
 
+          print(f'Fleet tests: {json.dumps(fleet_tests)}')
+          print(f'Standalone tests: {json.dumps(standalone_tests)}')
+
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
               fh.write(f'fleet_tests_list={json.dumps(fleet_tests)}\n')
               fh.write(f'standalone_tests_list={json.dumps(standalone_tests)}\n')

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -592,6 +592,7 @@ jobs:
         run: |
           set -e
           . .ci-venv/bin/activate
+          mkdir -p /tmp/ci
           integration-pipeline get_install_list \
             --manifest_platform_base_key product_components.simulator_components.plugins
           SIMULATOR_APT_PACKAGES="$(tr '\n' ' ' < packages.apt | xargs)"

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -167,7 +167,7 @@ jobs:
         password: ${{secrets.registry_password}}
     outputs:
       slack_thread_id: ${{ steps.send-message.outputs.ts }}
-      fleet_tests_list: ${{ steps.extract_fleet_tests_list.outputs.fleet_tests_list }}
+      fleet_tests_list: ${{ steps.extract_test_lists.outputs.fleet_tests_list }}
       standalone_tests_list: ${{ steps.extract_test_lists.outputs.standalone_tests_list }}
       default_pytest_args: ${{ steps.default_pytest_args.outputs.args }}
     steps:

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -464,7 +464,7 @@ jobs:
           docker image prune --all -f
 
   Validation-Standalone-Tests:
-    needs: [Build-backend, Validation-Standalone-Tests]
+    needs: [Validate-bootstrap-configs, Build-backend]
     if: ${{ needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '[]' && needs.Validate-bootstrap-configs.outputs.standalone_tests_list != '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -244,7 +244,17 @@ jobs:
 
       - name: Pass through default pytest args
         id: default_pytest_args
-        run: echo "args=${DEFAULT_PYTEST_ARGS}" >> $GITHUB_OUTPUT
+        shell: bash
+        run: |
+          echo "test_args='${test_args}'"
+          args="${DEFAULT_PYTEST_ARGS}"
+
+          if [[ -n "${test_args:-}" ]]; then
+            args="${test_args} ${DEFAULT_PYTEST_ARGS}"
+            echo "args=${args}"
+          fi
+
+          echo "args=${args}" >> "$GITHUB_OUTPUT"
 
       - name: Stash component_artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -470,7 +470,7 @@ jobs:
       fail-fast: false
       matrix:
         test_key: ${{ fromJson(needs.Validate-bootstrap-configs.outputs.standalone_tests_list || '[]') }}
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v2.3
+    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@feat/DP-2014_standalone-tests
     secrets: inherit
     with:
       collect_deployable_artifacts: ${{ matrix.test_key == 'ui_tests' || matrix.test_key == 'install_tests' }}
@@ -709,7 +709,7 @@ jobs:
 
   Simulator-Validations:
     needs: [Build-Simulator, Build-backend]
-    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@feat/DP-2014_standalone-tests
+    uses: MOV-AI/.github/.github/workflows/integration-platform-local-standalone-tests.yml@v3
     secrets: inherit
     with:
       test_infra_key: "simul_flow_tests"

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -584,6 +584,8 @@ jobs:
         if: ${{ steps.pre_simulator_build.outputs.skip_simulator_build == 'false' }}
         id: resolve_simulator_apt_packages
         shell: bash
+        env:
+          ROS_DISTRO: ${{ env.DISTRO }}
         run: |
           set -e
           . .ci-venv/bin/activate

--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -477,7 +477,7 @@ jobs:
       test_infra_key: ${{ matrix.test_key }}
       slack_thread_id: ${{ needs.Build-backend.outputs.slack_thread_id }}
       backend_image_name_and_tag: ${{ needs.Build-backend.outputs.backend_image }}
-      test_timeout: ${{ matrix.test_key == 'ui_tests' && 120 || 30 }}
+      test_timeout: ${{ (matrix.test_key == 'ui_tests' || matrix.test_key == 'flow_initiator') && 120 || 30 }}
       pytest_args: ${{ matrix.test_key == 'install_tests' && '-k "$test_set" --installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report' || needs.Validate-bootstrap-configs.outputs.default_pytest_args }}
       xray_label: ${{ matrix.test_key == 'ui_tests' && 'UI_Automation' || '' }}
       slack_channel: ${{ inputs.slack_channel }}


### PR DESCRIPTION
This PR modifies the integration build workflow in `.github/workflows/integration-build-platform.yml`. The main focus is on the test extraction and execution logic, especially for standalone tests. 

Changes:
- Replaced multiple specific validation jobs (`Validation-UI-Tests`, `Validation-Install-Tests`, etc.) with a single matrix-driven `Validation-Standalone-Tests` job. This job runs for each standalone test detected, dynamically sets parameters (such as timeouts and pytest arguments), and handles artifact collection as needed.

TODO: fix broken build-simulator (create another jira)

related to: https://github.com/MOV-AI/.github/pull/610