### PR TITLE
DP-2014 (v2.3): Refactor Integration Standalone Tests Workflow

### DIFF
--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -25,8 +25,9 @@ on:
         type: number
         default: 60
       pytest_args:
-        required: true
+        required: false
         type: string
+        default: ''
       xray_label:
         required: false
         type: string

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -331,6 +331,10 @@ jobs:
             PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
           fi
 
+          if [[ -n "${test_args:-}" ]]; then
+            PYTEST_ARGS="$test_args $PYTEST_ARGS"
+          fi
+
           echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"
           python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml
           deactivate

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -331,8 +331,10 @@ jobs:
             PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
           fi
 
-          if [[ -n "${test_args:-}" ]]; then
-            PYTEST_ARGS="$test_args $PYTEST_ARGS"
+          echo "$test_args"
+
+          if [[ -n "$test_args" && "$test_args" != "None" ]]; then
+              PYTEST_ARGS="$test_args $PYTEST_ARGS"
           fi
 
           echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -320,6 +320,7 @@ jobs:
           movai_user: ${{ steps.install.outputs.movai_user }}
           movai_pwd: ${{ steps.install.outputs.movai_pwd }}
           test_set: ${{ steps.infra_tests_setup.outputs.test_set }}
+          test_args: ${{ steps.infra_tests_setup.outputs.test_args }}
         run: |
           . test-venv/bin/activate
           pip install buildkite-test-collector

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -324,7 +324,15 @@ jobs:
           . test-venv/bin/activate
           pip install buildkite-test-collector
           echo "python3 -m pytest ${{ inputs.pytest_args}}"
-          python3 -m pytest ${{ inputs.pytest_args}} --junit-xml=junit.xml | tee pytest-output.log
+
+          if [[ -z "$test_set" || "$test_set" == "None" ]]; then
+            PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed 's/-m "\$test_set"[[:space:]]*//')
+          fi
+
+          echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"
+
+          python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml | tee pytest-output.log
+
           deactivate
 
       - name: Publish test results trunk

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -328,7 +328,7 @@ jobs:
 
           PYTEST_ARGS="${{ inputs.pytest_args }}"
 
-          if [[ -z "$test_set" || "$test_set" == "None" ]]; then
+          if [[ -z "$test_set" || "$test_set" == "'None'" ]]; then
             PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
           fi
 

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "tests_dir=${tests_dir}" >> $GITHUB_OUTPUT
           echo "jira_report=${jira_report}" >> $GITHUB_OUTPUT
-          echo "test_set='$test_set'" >> $GITHUB_OUTPUT
+          echo "test_set=${test_set}" >> $GITHUB_OUTPUT
           echo "platform_version=${platform_version}" >> $GITHUB_OUTPUT
           echo "test_args=${test_args}" >> $GITHUB_OUTPUT
           deactivate
@@ -328,8 +328,12 @@ jobs:
 
           PYTEST_ARGS="${{ inputs.pytest_args }}"
 
-          if [[ -z "$test_set" || "$test_set" == "'None'" ]]; then
+          if [[ -z "$test_set" || "$test_set" == "None" ]]; then
             PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
+          fi
+
+          if [[ -n "$test_set" && "$test_set" != "None" ]]; then
+              PYTEST_ARGS=${PYTEST_ARGS/-m "$test_set"/-m "\"$test_set\""}
           fi
 
           echo "$test_args"

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "tests_dir=${tests_dir}" >> $GITHUB_OUTPUT
           echo "jira_report=${jira_report}" >> $GITHUB_OUTPUT
-          echo "test_set=\"$test_set\"" >> $GITHUB_OUTPUT
+          echo "test_set=${test_set}" >> $GITHUB_OUTPUT
           echo "platform_version=${platform_version}" >> $GITHUB_OUTPUT
           echo "test_args=${test_args}" >> $GITHUB_OUTPUT
           deactivate

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -324,15 +324,16 @@ jobs:
           . test-venv/bin/activate
           pip install buildkite-test-collector
           echo "python3 -m pytest ${{ inputs.pytest_args}}"
+          echo "test_set: $test_set"
+
+          PYTEST_ARGS="${{ inputs.pytest_args }}"
 
           if [[ -z "$test_set" || "$test_set" == "None" ]]; then
             PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
           fi
 
           echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"
-
-          python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml | tee pytest-output.log
-
+          python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml
           deactivate
 
       - name: Publish test results trunk

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -329,6 +329,13 @@ jobs:
           # base cmd
           PYTEST_CMD=(python3 -m pytest --junit-xml=junit.xml)
 
+          # append test_args if exist
+          if [[ -n "$test_args" && "$test_args" != "None" ]]; then
+              PYTEST_CMD+=($test_args)
+          fi
+
+          PYTEST_CMD+=(--junit-xml=junit.xml)
+
           if [[ "${{ inputs.test_infra_key }}" == "install_tests" ]]; then
               PYTEST_CMD+=(--installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report)
 
@@ -342,11 +349,6 @@ jobs:
               if [[ -n "$test_set" && "$test_set" != "None" ]]; then
                   PYTEST_CMD+=(-m "$test_set")
               fi
-          fi
-
-          # append test_args if exist
-          if [[ -n "$test_args" && "$test_args" != "None" ]]; then
-              PYTEST_CMD+=($test_args)
           fi
 
           echo "exec: ${PYTEST_CMD[@]}"

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -324,26 +324,33 @@ jobs:
         run: |
           . test-venv/bin/activate
           pip install buildkite-test-collector
-          echo "python3 -m pytest ${{ inputs.pytest_args}}"
 
-          PYTEST_ARGS="${{ inputs.pytest_args }}"
+          # base cmd
+          PYTEST_CMD=(python3 -m pytest --junit-xml=junit.xml)
 
-          if [[ -z "$test_set" || "$test_set" == "None" ]]; then
-            PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
+          if [[ "${{ inputs.test_infra_key }}" == "install_tests" ]]; then
+              PYTEST_CMD+=(--installPath="$USERSPACE_FOLDER_PATH" --jsonConfigFilePath="../basic-standalone-noetic.json.ci" --jira_report)
+
+              if [[ -n "$test_set" && "$test_set" != "None" ]]; then
+                  PYTEST_CMD+=(-k "$test_set")
+              fi
+          else
+              # default
+              PYTEST_CMD+=(--movai-ip "$host_ip" --movai-user "$movai_user" --movai-pw "$movai_pwd")
+
+              if [[ -n "$test_set" && "$test_set" != "None" ]]; then
+                  PYTEST_CMD+=(-m "$test_set")
+              fi
           fi
 
-          if [[ -n "$test_set" && "$test_set" != "None" ]]; then
-              PYTEST_ARGS=${PYTEST_ARGS/-m "$test_set"/-m "\"$test_set\""}
-          fi
-
-          echo "$test_args"
-
+          # append test_args if exist
           if [[ -n "$test_args" && "$test_args" != "None" ]]; then
-              PYTEST_ARGS="$test_args $PYTEST_ARGS"
+              PYTEST_CMD+=($test_args)
           fi
 
-          echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"
-          python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml
+          echo "exec: ${PYTEST_CMD[@]}"
+          "${PYTEST_CMD[@]}"
+
           deactivate
 
       - name: Publish test results trunk

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -326,7 +326,7 @@ jobs:
           echo "python3 -m pytest ${{ inputs.pytest_args}}"
 
           if [[ -z "$test_set" || "$test_set" == "None" ]]; then
-            PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed 's/-m "\$test_set"[[:space:]]*//')
+            PYTEST_ARGS=$(echo "$PYTEST_ARGS" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
           fi
 
           echo "python3 -m pytest $PYTEST_ARGS --junit-xml=junit.xml"

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "tests_dir=${tests_dir}" >> $GITHUB_OUTPUT
           echo "jira_report=${jira_report}" >> $GITHUB_OUTPUT
-          echo "test_set=${test_set}" >> $GITHUB_OUTPUT
+          echo "test_set='$test_set'" >> $GITHUB_OUTPUT
           echo "platform_version=${platform_version}" >> $GITHUB_OUTPUT
           echo "test_args=${test_args}" >> $GITHUB_OUTPUT
           deactivate

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -166,7 +166,7 @@ jobs:
           # setup tests venv in a step that is always executed
           python3 -m venv "${tests_dir}"/test-venv --clear
           . "${tests_dir}"/test-venv/bin/activate
-          pip install -r "${tests_dir}"/requirements.txt
+          pip install -r "${tests_dir}"/test-requirements.txt
           deactivate
 
       - name: Feature File Validation

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "tests_dir=${tests_dir}" >> $GITHUB_OUTPUT
           echo "jira_report=${jira_report}" >> $GITHUB_OUTPUT
-          echo "test_set=${test_set}" >> $GITHUB_OUTPUT
+          echo "test_set=\"$test_set\"" >> $GITHUB_OUTPUT
           echo "platform_version=${platform_version}" >> $GITHUB_OUTPUT
           echo "test_args=${test_args}" >> $GITHUB_OUTPUT
           deactivate

--- a/.github/workflows/integration-platform-local-standalone-tests.yml
+++ b/.github/workflows/integration-platform-local-standalone-tests.yml
@@ -324,7 +324,6 @@ jobs:
           . test-venv/bin/activate
           pip install buildkite-test-collector
           echo "python3 -m pytest ${{ inputs.pytest_args}}"
-          echo "test_set: $test_set"
 
           PYTEST_ARGS="${{ inputs.pytest_args }}"
 


### PR DESCRIPTION
This PR modifies the integration build workflow in `.github/workflows/integration-platform-local-standalone-tests.yml`. The main focus is on the changes inside the standalone tests workflow, particularly the test execution logic.

Changes:

* Updated the standalone tests workflow, with the majority of the changes in the `Run tests` step.
* Removed the need for `pytest_args`, which is no longer used by the workflow. It is currently kept for retrocompatibility but is planned to be removed.

Related to: https://github.com/MOV-AI/.github/pull/608