### PR TITLE
Add simulation cluster selection to workflows and update cluster refe…

### DIFF
--- a/.github/workflows/integration-build-robotics-component.yml
+++ b/.github/workflows/integration-build-robotics-component.yml
@@ -20,6 +20,10 @@ on:
       test_set:
         required: true
         type: string
+      sim_cluster:
+        required: false
+        default: "any"
+        type: string
       cluster:
         required: false
         default: "mary"
@@ -75,8 +79,45 @@ env:
   SLACK_CHANNEL: "G0102LEV1CL"
 
 jobs:
+  Select-Simtest-Node:
+    runs-on: ubuntu-22.04
+    outputs:
+      sim_cluster: ${{ steps.select_sim_cluster.outputs.sim_cluster }}
+    steps:
+      - name: Checkout workflow scripts repository
+        uses: actions/checkout@v6
+        with:
+          repository: MOV-AI/.github
+          ref: v3
+          path: .github-workflows
+          token: ${{ secrets.auto_commit_pwd }}
+
+      - name: Select simulation cluster
+        id: select_sim_cluster
+        shell: bash
+        run: |
+          set -e
+          selected_cluster="${{ inputs.sim_cluster }}"
+          if [[ -z "$selected_cluster" ]]; then
+            selected_cluster="${{ inputs.cluster }}"
+          fi
+
+          if [[ "$selected_cluster" == "any" || -z "$selected_cluster" ]]; then
+            selected_cluster="$(bash .github-workflows/.github/scripts/select_gpu_free_node.sh)"
+          fi
+
+          if [[ -z "$selected_cluster" ]]; then
+            echo "::error::Simulation cluster is empty. Provide cluster/sim_cluster or use 'any'."
+            exit 1
+          fi
+
+          echo "sim_cluster=$selected_cluster" >> "$GITHUB_OUTPUT"
+
   Stack-tests:
-    runs-on: simul-${{ inputs.cluster }}-queuer
+    needs: [Select-Simtest-Node]
+    runs-on: simul-${{ needs.Select-Simtest-Node.outputs.sim_cluster }}-queuer
+    env:
+      RESOLVED_CLUSTER: ${{ needs.Select-Simtest-Node.outputs.sim_cluster }}
 
     steps:
       - name: Cleanup Workspace
@@ -156,9 +197,9 @@ jobs:
 
           run_type="ci"
 
-          local_manager_prefix="ip-$run_type-${{ inputs.cluster }}-${{ inputs.component_name }}-$branch"
+          local_manager_prefix="ip-$run_type-${{ env.RESOLVED_CLUSTER }}-${{ inputs.component_name }}-$branch"
 
-          tf_state="${{ inputs.cluster }}-sim-$local_manager_prefix"
+          tf_state="${{ env.RESOLVED_CLUSTER }}-sim-$local_manager_prefix"
           echo "tf_state = $tf_state"
           echo "local_manager_prefix = $local_manager_prefix"
 
@@ -170,10 +211,10 @@ jobs:
         working-directory: ${{ steps.provision_infra_setup.outputs.target_dir }}
         shell: bash
         run: |
-          multiply_node=$(printf '"${{ inputs.cluster }}",%.0s' {1..1})
+          multiply_node=$(printf '"${{ env.RESOLVED_CLUSTER }}",%.0s' {1..1})
           node_list_str=${multiply_node::-1}
 
-          var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ inputs.cluster }}_simul_bpg.tfvars'
+          var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ env.RESOLVED_CLUSTER }}_simul_bpg.tfvars'
 
           echo "proxmox_host_list=[$node_list_str]">>input.tfvars
           echo "fleet_peer_nr=0">>input.tfvars
@@ -188,7 +229,7 @@ jobs:
 
           echo "File args: $var_file_arg"
           echo "Input File args: $(cat input.tfvars)"
-          terraform init -backend-config="key=${{ inputs.cluster }}-ci-simul-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
+          terraform init -backend-config="key=${{ env.RESOLVED_CLUSTER }}-ci-simul-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
           terraform apply -auto-approve $var_file_arg -var-file=input.tfvars
           terraform refresh $var_file_arg -var-file=input.tfvars
 
@@ -512,7 +553,7 @@ jobs:
           attempts=3
           count=0
           while [ $count -lt $attempts ]; do
-            var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ inputs.cluster }}_simul_bpg.tfvars'
+            var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ env.RESOLVED_CLUSTER }}_simul_bpg.tfvars'
             terraform destroy -auto-approve $var_file_arg -var-file=input.tfvars -var "fleet_peer_nr=0"
             exit_status=$?
             if [ $exit_status -eq 0 ]; then

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -5,6 +5,10 @@ on:
       product_name:
         required: true
         type: string
+      sim_cluster:
+        required: false
+        default: "any"
+        type: string
       cluster:
         required: false
         default: "mary"
@@ -98,8 +102,45 @@ env:
   PROVISION_ENV_CONF_DIR: "infra_env_configs"
 
 jobs:
+  Select-Simtest-Node:
+    runs-on: ubuntu-22.04
+    outputs:
+      sim_cluster: ${{ steps.select_sim_cluster.outputs.sim_cluster }}
+    steps:
+      - name: Checkout workflow scripts repository
+        uses: actions/checkout@v6
+        with:
+          repository: MOV-AI/.github
+          ref: v3
+          path: .github-workflows
+          token: ${{ secrets.gh_token }}
+
+      - name: Select simulation cluster
+        id: select_sim_cluster
+        shell: bash
+        run: |
+          set -e
+          selected_cluster="${{ inputs.sim_cluster }}"
+          if [[ -z "$selected_cluster" ]]; then
+            selected_cluster="${{ inputs.cluster }}"
+          fi
+
+          if [[ "$selected_cluster" == "any" || -z "$selected_cluster" ]]; then
+            selected_cluster="$(bash .github-workflows/.github/scripts/select_gpu_free_node.sh)"
+          fi
+
+          if [[ -z "$selected_cluster" ]]; then
+            echo "::error::Simulation cluster is empty. Provide cluster/sim_cluster or use 'any'."
+            exit 1
+          fi
+
+          echo "sim_cluster=$selected_cluster" >> "$GITHUB_OUTPUT"
+
   Robotic-Stack-Integration:
-    runs-on: simul-${{ inputs.cluster }}-queuer
+    needs: [Select-Simtest-Node]
+    runs-on: simul-${{ needs.Select-Simtest-Node.outputs.sim_cluster }}-queuer
+    env:
+      RESOLVED_CLUSTER: ${{ needs.Select-Simtest-Node.outputs.sim_cluster }}
     steps:
       - name: Cleanup Workspace
         uses: rtCamp/action-cleanup@master
@@ -187,9 +228,9 @@ jobs:
 
           run_type="ci"
 
-          local_manager_prefix="ip-$run_type-${{ inputs.cluster }}-${{ inputs.product_name }}-$branch"
+          local_manager_prefix="ip-$run_type-${{ env.RESOLVED_CLUSTER }}-${{ inputs.product_name }}-$branch"
 
-          tf_state="${{ inputs.cluster }}-sim-$local_manager_prefix"
+          tf_state="${{ env.RESOLVED_CLUSTER }}-sim-$local_manager_prefix"
           echo "simul_prefix=${local_manager_prefix}" | tee >> $GITHUB_OUTPUT
           echo "tfstate_name=${tf_state}" | tee >> $GITHUB_OUTPUT
 
@@ -197,10 +238,10 @@ jobs:
         working-directory: ${{ steps.provision_infra_setup.outputs.target_dir }}
         shell: bash
         run: |
-          multiply_node=$(printf '"${{ inputs.cluster }}",%.0s' {1..1})
+          multiply_node=$(printf '"${{ env.RESOLVED_CLUSTER }}",%.0s' {1..1})
           node_list_str=${multiply_node::-1}
 
-          var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ inputs.cluster }}_simul_bpg.tfvars'
+          var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ env.RESOLVED_CLUSTER }}_simul_bpg.tfvars'
 
           echo "proxmox_host_list=[$node_list_str]">>input.tfvars
           echo "fleet_peer_nr=0">>input.tfvars
@@ -215,7 +256,7 @@ jobs:
 
           echo "File args: $var_file_arg"
           echo "Input File args: $(cat input.tfvars)"
-          terraform init -backend-config="key=${{ inputs.cluster }}-ci-simul-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
+          terraform init -backend-config="key=${{ env.RESOLVED_CLUSTER }}-ci-simul-${{ steps.infra_names.outputs.simul_prefix }}.tfstate"
           terraform apply -auto-approve $var_file_arg -var-file=input.tfvars
           terraform refresh $var_file_arg -var-file=input.tfvars
 
@@ -761,7 +802,7 @@ jobs:
           attempts=3
           count=0
           while [ $count -lt $attempts ]; do
-            var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ inputs.cluster }}_simul_bpg.tfvars'
+            var_file_arg='-var-file=../${{ steps.infra_env_configs_setup.outputs.target_dir }}/marvin/${{ env.RESOLVED_CLUSTER }}_simul_bpg.tfvars'
             terraform destroy -auto-approve $var_file_arg -var-file=input.tfvars -var "fleet_peer_nr=0"
             exit_status=$?
             if [ $exit_status -eq 0 ]; then

--- a/.github/workflows/ros-workflow.yml
+++ b/.github/workflows/ros-workflow.yml
@@ -73,7 +73,7 @@ on:
         type: string
       cluster:
         required: false
-        default: "mary"
+        default: "any"
         type: string
       debug_component_tests_keep_alive:
         required: false
@@ -457,9 +457,42 @@ jobs:
           python3 -m pip install -i https://artifacts.cloud.mov.ai/repository/pypi-integration/simple --extra-index-url https://pypi.org/simple mobtest==${{ inputs.MOBTEST_VERSION }} --ignore-installed
           mobtest proj /opt/ros/${{ matrix.distro }}/share/
 
-  Package-Stack-Tests:
+  Select-Simtest-Node:
     if: ${{ always() && inputs.release == 'false' && inputs.deploy == 'true' && inputs.run_stack_tests && needs.Build.result == 'success' && (needs.Post-build-static-analysis.result == 'success' || needs.Post-build-static-analysis.result == 'skipped') }}
     needs: [Build,Post-build-static-analysis]
+    runs-on: ubuntu-22.04
+    outputs:
+      resolved_cluster: ${{ steps.select_sim_cluster.outputs.resolved_cluster }}
+    steps:
+      - name: Checkout workflow scripts repository
+        uses: actions/checkout@v6
+        with:
+          repository: MOV-AI/.github
+          ref: v3
+          path: .github-workflows
+          token: ${{ secrets.gh_token }}
+
+      - name: Select simulation cluster
+        id: select_sim_cluster
+        shell: bash
+        run: |
+          set -e
+          selected_cluster="${{ inputs.cluster }}"
+          if [[ "$selected_cluster" == "any" || -z "$selected_cluster" ]]; then
+            selector_script=".github-workflows/.github/scripts/select_gpu_free_node.sh"
+            selected_cluster="$(bash "$selector_script")"
+          fi
+
+          if [[ -z "$selected_cluster" ]]; then
+            echo "::error::Simulation cluster is empty. Provide cluster/sim_cluster or use 'any'."
+            exit 1
+          fi
+
+          echo "resolved_cluster=$selected_cluster" >> "$GITHUB_OUTPUT"
+
+  Package-Stack-Tests:
+    if: ${{ always() && inputs.release == 'false' && inputs.deploy == 'true' && inputs.run_stack_tests && needs.Build.result == 'success' && (needs.Post-build-static-analysis.result == 'success' || needs.Post-build-static-analysis.result == 'skipped') }}
+    needs: [Build,Post-build-static-analysis,Select-Simtest-Node]
     uses: MOV-AI/.github/.github/workflows/integration-build-robotics-component.yml@v2.3
     with:
       vs_product_name: ${{ inputs.vs_product_name }}
@@ -468,7 +501,7 @@ jobs:
       test_repo_name: ${{ inputs.test_repo_name }}
       test_set: ${{ inputs.test_set }}
       test_version: ${{ inputs.test_version }}
-      cluster: ${{ inputs.cluster }}
+      cluster: ${{ needs.Select-Simtest-Node.outputs.resolved_cluster }}
       debug_component_tests_keep_alive: ${{ inputs.debug_component_tests_keep_alive }}
     secrets: inherit
 


### PR DESCRIPTION
This pull request enhances the GitHub Actions workflows for robotics component and stack integration tests by introducing dynamic selection of simulation clusters. It adds a new job to select an available simulation cluster node automatically when not explicitly specified, improving flexibility and resource utilization. The workflows now consistently use the resolved cluster value throughout the provisioning, Terraform, and test steps, reducing manual configuration and potential errors.

**Simulation cluster selection and workflow orchestration:**

* Added a `Select-Simtest-Node` job to `.github/workflows/integration-build-robotics-component.yml`, `.github/workflows/integration-robotic-stack-tests.yml`, and `.github/workflows/ros-workflow.yml` that determines the simulation cluster to use, either from input or by auto-selecting a free node with the `select_gpu_free_node.sh` script. [[1]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073R82-R120) [[2]](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cR105-R143) [[3]](diffhunk://#diff-84e2a093673745a3f2959e4cce86234e2656a3899efb6d77bda179858622aec7L460-R495)
* Introduced a new `sim_cluster` input parameter (default: "any") to allow users to specify or auto-select a simulation cluster. [[1]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073R23-R26) [[2]](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cR8-R11)
* Changed the default value of the `cluster` input in `ros-workflow.yml` from "mary" to "any" to encourage auto-selection unless overridden.

**Consistent use of resolved cluster:**

* Updated all references in subsequent jobs (e.g., `Stack-tests`, `Robotic-Stack-Integration`, `Package-Stack-Tests`) to use the dynamically resolved cluster (`RESOLVED_CLUSTER` or `resolved_cluster`) for runner selection, Terraform state naming, and variable files, ensuring all steps use the selected cluster. [[1]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073L159-R202) [[2]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073L173-R217) [[3]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073L191-R232) [[4]](diffhunk://#diff-4b5ff350d46b7d4de65b44a0035b66b6f575614f060d400da47e884f4d927073L515-R556) [[5]](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL190-R244) [[6]](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL218-R259) [[7]](diffhunk://#diff-de1d24066f4c1d29001df9486e45f7072ee9c525203e790e275b90a32e9e076cL764-R805) [[8]](diffhunk://#diff-84e2a093673745a3f2959e4cce86234e2656a3899efb6d77bda179858622aec7L471-R504)

These changes make the workflows more robust, flexible, and easier to maintain, especially in multi-cluster environments.