### PR TITLE
hotfix/robotic tests failing ---> TO BE REVERTED (after robotics tests are fixed)

### DIFF
--- a/.github/workflows/integration-build-platform.yml
+++ b/.github/workflows/integration-build-platform.yml
@@ -747,7 +747,7 @@ jobs:
   Robotic-Stack-Integration:
     if: ${{ inputs.with_robotic_stack_tests }}
     needs: [Select-Simtest-Node, Simulator-Validations, Build-backend, Build-Simulator]
-    uses: MOV-AI/.github/.github/workflows/integration-robotic-stack-tests.yml@feat/select_sim_cluster
+    uses: MOV-AI/.github/.github/workflows/integration-robotic-stack-tests.yml@hotfix/robotic-tests-failing
     secrets: inherit
     with:
       product_name: ${{ inputs.product_name }}

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -507,6 +507,7 @@ jobs:
               movai-cli robots user "$robot" "$MOVAI_USER" "$MOVAI_PWD"
               movai-cli set "$robot" orchestrator.extra-env "RAISE_FLOW_VALIDATION_ERRORS=False"
               movai-cli restart "$robot"
+              sleep 60
             done
 
             execution_status=$?

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -507,7 +507,11 @@ jobs:
               movai-cli robots user "$robot" "$MOVAI_USER" "$MOVAI_PWD"
               movai-cli set "$robot" orchestrator.extra-env "RAISE_FLOW_VALIDATION_ERRORS=False"
               movai-cli restart "$robot"
-              sleep 60
+              sleep 5
+
+              wget https://movai-scripts.s3.amazonaws.com/wait_robot_start.bash
+              chmod +x ./wait_robot_start.bash
+              ./wait_robot_start.bash
             done
 
             execution_status=$?

--- a/.github/workflows/integration-robotic-stack-tests.yml
+++ b/.github/workflows/integration-robotic-stack-tests.yml
@@ -505,6 +505,8 @@ jobs:
             MOVAI_PWD="4Iva6UHAQq9DGITj"
             for robot in $(movai-cli robots list); do
               movai-cli robots user "$robot" "$MOVAI_USER" "$MOVAI_PWD"
+              movai-cli set "$robot" orchestrator.extra-env "RAISE_FLOW_VALIDATION_ERRORS=False"
+              movai-cli restart "$robot"
             done
 
             execution_status=$?


### PR DESCRIPTION
robotics tests are currently blocking the pipeline. Since there is no guarantee that the tests will be fixed in time, so we need a temporary hotfix to unblock the pipeline.

